### PR TITLE
Fix small bug that causes the worker to transfer empty batches for migration in every epoch

### DIFF
--- a/worker/transactional_protocols/aria.py
+++ b/worker/transactional_protocols/aria.py
@@ -347,7 +347,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         return start_wal, end_wal
 
     async def send_async_migrate_batch(self):
-        if USE_ASYNC_MIGRATION and self.local_state.has_keys_to_send:
+        if USE_ASYNC_MIGRATION and self.local_state.has_keys_to_send():
             batch = self.local_state.get_async_migrate_batch(ASYNC_MIGRATION_BATCH_SIZE)
             for operator_partition, k_v_pairs in batch.items():
                 operator_name, partition = operator_partition


### PR DESCRIPTION
In `send_async_migrate_batch` the `has_keys_to_send()` method is not being called properly, which makes the if condition evaluate to true in every call. This causes unnecessary overhead, as in each epoch the worker will essentially transfer empty batches to its peers, even while migration is not occurring. 