### PR TITLE
Add LocalStyxRunner for zero-infrastructure function testing

### DIFF
--- a/demo/demo-local-runner/client.py
+++ b/demo/demo-local-runner/client.py
@@ -1,0 +1,106 @@
+"""Local runner demo — runs the YCSB workload with zero infrastructure.
+
+Usage:
+    python demo/demo-local-runner/client.py
+
+This demo uses the same YCSB operator functions as demo-ycsb but executes
+them locally via LocalStyxRunner instead of the distributed Styx cluster.
+No Kafka, S3, coordinator, or workers are required.
+"""
+
+import asyncio
+import random
+import time
+
+from styx.common.local_state_backends import LocalStateBackend
+from styx.common.stateflow_graph import StateflowGraph
+from styx.local_runner import LocalStyxRunner
+
+from ycsb import NotEnoughCredit, ycsb_operator
+
+# Configuration
+N_ENTITIES = 100
+N_PARTITIONS = 4
+STARTING_MONEY = 1_000_000
+N_TRANSFERS = 500
+CONCURRENCY = 50  # number of concurrent transfers in flight
+
+
+async def run_transfer(runner, key_a, key_b):
+    """Run a single transfer, returning 1 if aborted."""
+    try:
+        await runner.send_event(
+            "ycsb",
+            key=key_a,
+            function="transfer",
+            params=(key_b,),
+        )
+    except NotEnoughCredit:
+        return 1
+    return 0
+
+
+async def main() -> None:
+    # 1. Build graph — identical to production setup
+    g = StateflowGraph(
+        "ycsb-benchmark",
+        operator_state_backend=LocalStateBackend.DICT,
+        max_operator_parallelism=N_PARTITIONS,
+    )
+    ycsb_operator.set_n_partitions(N_PARTITIONS)
+    g.add_operators(ycsb_operator)
+
+    # 2. Create runner and seed data
+    runner = LocalStyxRunner(graph=g)
+    runner.init_data("ycsb", {i: STARTING_MONEY for i in range(N_ENTITIES)})
+
+    print(f"Initialized {N_ENTITIES} accounts with {STARTING_MONEY} each")
+    print(f"Total money supply: {N_ENTITIES * STARTING_MONEY}")
+    print()
+
+    # 3. Run concurrent transfers in batches
+    print(f"Running {N_TRANSFERS} transfers (concurrency={CONCURRENCY})...")
+    start = time.perf_counter()
+    aborted = 0
+
+    # Generate all transfer pairs upfront
+    pairs = []
+    for _ in range(N_TRANSFERS):
+        key_a = random.randint(0, N_ENTITIES - 1)
+        key_b = random.randint(0, N_ENTITIES - 1)
+        while key_b == key_a:
+            key_b = random.randint(0, N_ENTITIES - 1)
+        pairs.append((key_a, key_b))
+
+    # Execute in concurrent batches
+    for batch_start in range(0, N_TRANSFERS, CONCURRENCY):
+        batch = pairs[batch_start : batch_start + CONCURRENCY]
+        results = await asyncio.gather(
+            *(run_transfer(runner, a, b) for a, b in batch),
+        )
+        aborted += sum(results)
+
+    elapsed = time.perf_counter() - start
+    print(f"Completed in {elapsed:.3f}s ({N_TRANSFERS / elapsed:.0f} txn/s)")
+    print(f"Aborted (insufficient credit): {aborted}")
+    print()
+
+    # 4. Validate: total money supply is conserved
+    state = runner.get_state("ycsb")
+    total = sum(state.values())
+    expected = N_ENTITIES * STARTING_MONEY
+    print(f"Final money supply: {total}")
+    print(f"Expected:           {expected}")
+    assert total == expected, f"Money supply mismatch: {total} != {expected}"
+    print("Conservation check PASSED")
+    print()
+
+    # 5. Spot-check reads
+    print("Spot-checking 5 random accounts:")
+    for key in random.sample(range(N_ENTITIES), 5):
+        result = await runner.send_event("ycsb", key=key, function="read")
+        print(f"  account {result[0]:>3d}: balance = {result[1]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/demo/demo-local-runner/ycsb.py
+++ b/demo/demo-local-runner/ycsb.py
@@ -1,0 +1,62 @@
+from styx.common.operator import Operator
+from styx.common.stateful_function import StatefulFunction
+
+ycsb_operator = Operator("ycsb")
+
+
+class NotEnoughCredit(Exception):
+    pass
+
+
+@ycsb_operator.register
+async def insert(ctx: StatefulFunction):
+    value: int = 1_000_000
+    ctx.put(value)
+    return ctx.key
+
+
+@ycsb_operator.register
+async def insert_batch(ctx: StatefulFunction, key_value_pairs: dict[any, any]):
+    ctx.batch_insert(key_value_pairs)
+
+
+@ycsb_operator.register
+async def read(ctx: StatefulFunction):
+    value: int = ctx.get()
+    return ctx.key, value
+
+
+@ycsb_operator.register
+async def update(ctx: StatefulFunction):
+    new_value = ctx.get()
+    new_value += 1
+    ctx.put(new_value)
+    return ctx.key, new_value
+
+
+@ycsb_operator.register
+async def update_t(ctx: StatefulFunction):
+    new_value = ctx.get()
+    new_value += 1
+    ctx.put(new_value)
+
+
+@ycsb_operator.register
+async def transfer(ctx: StatefulFunction, key_b: str):
+    value_a = ctx.get()
+
+    ctx.call_remote_async(
+        operator_name="ycsb",
+        function_name="update_t",
+        key=key_b,
+    )
+
+    value_a -= 1
+
+    if value_a < 0:
+        msg = f"Not enough credit for user: {ctx.key}"
+        raise NotEnoughCredit(msg)
+
+    ctx.put(value_a)
+
+    return ctx.key, value_a

--- a/styx-package/styx/local_runner/README.md
+++ b/styx-package/styx/local_runner/README.md
@@ -1,0 +1,251 @@
+# Styx Local Runner
+
+An in-process executor for Styx stateful functions.
+Runs your functions against a plain dict-backed state with **zero infrastructure** — no Kafka, S3, coordinator, or workers required.
+
+Use it to validate function logic (get/put/chaining) before deploying to a full Styx cluster.
+
+## Installation
+
+The local runner ships with the `styx-package`:
+
+```bash
+pip install -e styx-package/
+```
+
+No additional dependencies are needed.
+
+## Quick Start
+
+```python
+import asyncio
+from styx.common.local_state_backends import LocalStateBackend
+from styx.common.operator import Operator
+from styx.common.stateflow_graph import StateflowGraph
+from styx.local_runner import LocalStyxRunner
+
+# 1. Define your graph — identical to production
+g = StateflowGraph("my-app", operator_state_backend=LocalStateBackend.DICT)
+op = Operator("accounts", n_partitions=4)
+
+@op.register
+async def read(ctx):
+    return ctx.key, ctx.get()
+
+@op.register
+async def deposit(ctx, amount):
+    balance = ctx.get() or 0
+    balance += amount
+    ctx.put(balance)
+    return ctx.key, balance
+
+g.add_operator(op)
+
+# 2. Create runner and seed state
+runner = LocalStyxRunner(graph=g)
+runner.init_data("accounts", {0: 1000, 1: 2000})
+
+# 3. Execute functions
+async def main():
+    result = await runner.send_event("accounts", key=0, function="read")
+    print(result)  # (0, 1000)
+
+    result = await runner.send_event("accounts", key=0, function="deposit", params=(500,))
+    print(result)  # (0, 1500)
+
+asyncio.run(main())
+```
+
+## API Reference
+
+### `LocalStyxRunner(graph)`
+
+Create a runner from a `StateflowGraph`. Initializes all operator partitions.
+
+### `runner.init_data(operator_name, key_value_pairs)`
+
+Pre-populate state for an operator. Keys are automatically routed to the correct partition using the same `HashPartitioner` as production.
+
+```python
+runner.init_data("accounts", {0: 1000, 1: 2000, 2: 500})
+```
+
+### `await runner.send_event(operator_name, key, function, params=())`
+
+Execute a single function. Returns whatever the user function returns. Chained `call_remote_async` calls are executed depth-first after the function completes.
+
+```python
+result = await runner.send_event("accounts", key=0, function="deposit", params=(100,))
+```
+
+### `runner.send_event_sync(operator_name, key, function, params=())`
+
+Synchronous wrapper that calls `asyncio.run()` internally. Convenient for scripts and REPLs.
+
+```python
+result = runner.send_event_sync("accounts", key=0, function="read")
+```
+
+**Caveat:** Cannot be called from within an already-running event loop (Jupyter notebooks, pytest-asyncio). Use `await send_event()` in those contexts.
+
+### `await runner.send_batch(events)`
+
+Execute a list of events sequentially. Each event is a tuple of `(operator_name, key, function, params)`.
+
+```python
+results = await runner.send_batch([
+    ("accounts", 0, "read", ()),
+    ("accounts", 1, "deposit", (100,)),
+])
+```
+
+### `runner.get_state(operator_name)`
+
+Return a merged dict of all state across all partitions for an operator. Useful for assertions and debugging.
+
+```python
+state = runner.get_state("accounts")
+# {0: 1500, 1: 2000, 2: 500}
+```
+
+## Concurrent Execution
+
+`send_event` is safe to call concurrently with `asyncio.gather()`. The runner uses per-key `asyncio.Lock` to serialize access to the same key, while allowing full parallelism across different keys.
+
+```python
+# Run 50 transfers concurrently
+await asyncio.gather(
+    runner.send_event("accounts", key=0, function="deposit", params=(10,)),
+    runner.send_event("accounts", key=1, function="deposit", params=(20,)),
+    runner.send_event("accounts", key=2, function="deposit", params=(30,)),
+    # ...
+)
+```
+
+### How locking works
+
+1. Before executing a function, the runner acquires the lock for `(operator_name, key)`.
+2. The user function runs while the lock is held — `get()` and `put()` are protected.
+3. The lock is **released before** any chained `call_remote_async` calls execute.
+4. Each chained call then acquires its own key lock independently.
+
+This design prevents deadlocks on bidirectional chains (e.g. concurrent `transfer(A→B)` and `transfer(B→A)`).
+
+### Concurrency caveats
+
+- Concurrent calls to the **same key** are serialized (one at a time). This is correct but means throughput on a single hot key is limited.
+- Chained calls execute **after** the parent's lock is released. Between the parent's `put()` and the child's execution, another concurrent task could modify the parent's key. This differs from production where the entire transaction (parent + chains) is atomic within an epoch.
+
+## Function Chaining
+
+`call_remote_async` works as expected. The runner resolves chained calls depth-first:
+
+```python
+@op.register
+async def transfer(ctx, to_key, amount):
+    balance = ctx.get()
+    balance -= amount
+    ctx.put(balance)
+    ctx.call_remote_async("accounts", "credit", key=to_key, params=(amount,))
+    return ctx.key, balance
+
+@op.register
+async def credit(ctx, amount):
+    balance = ctx.get() or 0
+    balance += amount
+    ctx.put(balance)
+```
+
+After `transfer` returns, the runner immediately executes `credit` on the target key. If `credit` itself calls `call_remote_async`, those are executed next (depth-first recursion).
+
+Cross-operator chains work the same way:
+
+```python
+ctx.call_remote_async("inventory", "deduct", key=item_id, params=(qty,))
+```
+
+## Partitioning
+
+The runner uses the real `HashPartitioner` (via `operator.which_partition(key)`) so keys land in the same partitions as they would in production. This matters when using `ctx.data` which returns all state in the current partition.
+
+## What the Local Runner Provides
+
+- Validate that `get`/`put`/`call_remote_async` calls are wired correctly
+- Test function return values and state mutations
+- Verify chaining logic across operators
+- Catch exceptions raised by user functions
+- Debug with `get_state()` to inspect all state at any point
+- Concurrent execution with per-key safety via `asyncio.gather()`
+- Same partitioning behavior as production
+
+## Limitations and Differences from Production
+
+Understanding these differences is critical. Passing local tests does **not** guarantee production correctness.
+
+### No transactional semantics
+
+In production, Styx uses the Aria protocol to execute functions in epoch-based batches with optimistic concurrency control. Conflicting transactions are detected and aborted. The local runner has **none of this** — `put()` writes are immediate and permanent, there is no abort/retry mechanism, and there are no epochs.
+
+**Impact:** Code that relies on transaction atomicity across multiple keys (beyond what per-key locking provides) may behave differently in production.
+
+### No conflict detection
+
+In production, concurrent writes to the same key within an epoch trigger conflict detection, and one transaction is aborted and retried. Locally, concurrent writes to the same key are serialized by the per-key lock — they always succeed but the "last writer wins" based on lock acquisition order.
+
+**Impact:** Write-write conflicts that would cause aborts in production are invisible locally.
+
+### DFS chain execution
+
+In production, `call_remote_async` chains execute in the next epoch batch or concurrently across workers. Locally, chains execute synchronously and depth-first after the parent function returns, and **after** the parent key's lock is released.
+
+**Impact:**
+- Code that depends on chain execution order relative to other concurrent transactions may behave differently.
+- The window between the parent's `put()` and the child's execution is a point where concurrent tasks can interleave.
+
+### No serialization round-trip
+
+In production, function parameters and state values are serialized (msgpack) when sent across the network. The local runner passes Python objects directly. Values that are not msgpack-serializable will work locally but fail in production.
+
+**Impact:** Test with production-representative data types (strings, numbers, lists, dicts) rather than arbitrary Python objects.
+
+### API drift risk
+
+`LocalStatefulFunction` duck-types the real `StatefulFunction`. If `StatefulFunction` gains new methods (or changes signatures), the local runner will silently diverge. Code that works locally may call a method that doesn't exist in the local context, or vice versa.
+
+The user-facing methods that are mirrored:
+- `ctx.key` (property)
+- `ctx.data` (property)
+- `ctx.get()`
+- `ctx.put(value)`
+- `ctx.batch_insert(kv_pairs)`
+- `ctx.call_remote_async(operator_name, function_name, key, params)`
+
+### `send_event_sync` and event loops
+
+`send_event_sync` uses `asyncio.run()` internally, which creates a new event loop. This fails if called from within an already-running loop:
+
+- **Jupyter notebooks**: Use `await runner.send_event(...)` directly in cells
+- **pytest-asyncio**: Use `async def test_...` with `await runner.send_event(...)`
+- **Scripts**: `send_event_sync` works fine
+
+### Python recursion limit
+
+Chains are executed via recursive calls to `_execute_function`. Python's default recursion limit (1000) acts as a guard against infinite chains. Deeply nested chains (>500 levels) may hit this limit.
+
+## Demo
+
+A full working demo is at `demo/demo-local-runner/`:
+
+```bash
+python demo/demo-local-runner/client.py
+```
+
+It runs 500 concurrent YCSB transfers across 100 accounts and validates that the total money supply is conserved. See `demo/demo-local-runner/client.py` for the source.
+
+## Running Tests
+
+```bash
+pytest tests/unit/styx_package/test_local_runner.py -v
+```
+
+The test suite covers state basics, function execution, chaining, cross-operator chains, error handling, batch execution, sync wrapper, and concurrent execution (including bidirectional transfer deadlock safety).

--- a/styx-package/styx/local_runner/__init__.py
+++ b/styx-package/styx/local_runner/__init__.py
@@ -1,0 +1,3 @@
+from styx.local_runner.runner import LocalStyxRunner
+
+__all__ = ["LocalStyxRunner"]

--- a/styx-package/styx/local_runner/local_context.py
+++ b/styx-package/styx/local_runner/local_context.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from styx.common.types import K, V
+    from styx.local_runner.local_state import LocalOperatorState
+
+
+class LocalStatefulFunction:
+    """Duck-typed replacement for StatefulFunction for local execution.
+
+    Provides the same user-facing interface (key, data, get, put,
+    batch_insert, call_remote_async) without requiring distributed
+    runtime dependencies.
+    """
+
+    def __init__(
+        self,
+        key: K,
+        operator_name: str,
+        partition: int,
+        state: LocalOperatorState,
+    ) -> None:
+        self._key = key
+        self._operator_name = operator_name
+        self._partition = partition
+        self._state = state
+        self._remote_calls: list[tuple[str, str, K, tuple]] = []
+
+    @property
+    def key(self) -> K:
+        return self._key
+
+    @property
+    def data(self) -> dict[K, V]:
+        return self._state.get_all(self._operator_name, self._partition)
+
+    def get(self) -> V:
+        return self._state.get(self._key, self._operator_name, self._partition)
+
+    def put(self, value: V) -> None:
+        self._state.put(self._key, value, self._operator_name, self._partition)
+
+    def batch_insert(self, kv_pairs: dict[K, V]) -> None:
+        if kv_pairs:
+            self._state.batch_insert(kv_pairs, self._operator_name, self._partition)
+
+    def call_remote_async(
+        self,
+        operator_name: str,
+        function_name: type | str,
+        key: K,
+        params: tuple = (),
+    ) -> None:
+        if isinstance(function_name, type):
+            function_name = function_name.__name__
+        self._remote_calls.append((operator_name, function_name, key, params))
+
+    def drain_remote_calls(self) -> list[tuple[str, str, K, tuple]]:
+        calls = self._remote_calls
+        self._remote_calls = []
+        return calls

--- a/styx-package/styx/local_runner/local_state.py
+++ b/styx-package/styx/local_runner/local_state.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from styx.common.types import K, V
+
+
+class LocalOperatorState:
+    """Minimal dict-backed state for local runner execution.
+
+    State is keyed by (operator_name, partition) -> {key: value}.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[tuple[str, int], dict[K, V]] = {}
+
+    def init_partition(self, operator_name: str, partition: int) -> None:
+        self._data.setdefault((operator_name, partition), {})
+
+    def get(self, key: K, operator_name: str, partition: int) -> V:
+        return self._data[(operator_name, partition)].get(key)
+
+    def put(self, key: K, value: V, operator_name: str, partition: int) -> None:
+        self._data[(operator_name, partition)][key] = value
+
+    def get_all(self, operator_name: str, partition: int) -> dict[K, V]:
+        return dict(self._data.get((operator_name, partition), {}))
+
+    def batch_insert(self, kv_pairs: dict[K, V], operator_name: str, partition: int) -> None:
+        self._data.setdefault((operator_name, partition), {}).update(kv_pairs)

--- a/styx-package/styx/local_runner/local_state.py
+++ b/styx-package/styx/local_runner/local_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,10 +11,21 @@ class LocalOperatorState:
     """Minimal dict-backed state for local runner execution.
 
     State is keyed by (operator_name, partition) -> {key: value}.
+    Per-key asyncio locks protect concurrent access.
     """
 
     def __init__(self) -> None:
         self._data: dict[tuple[str, int], dict[K, V]] = {}
+        self._key_locks: dict[tuple[str, K], asyncio.Lock] = {}
+
+    def key_lock(self, operator_name: str, key: K) -> asyncio.Lock:
+        """Return (or create) the asyncio.Lock for a given operator + key."""
+        lock_key = (operator_name, key)
+        lock = self._key_locks.get(lock_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._key_locks[lock_key] = lock
+        return lock
 
     def init_partition(self, operator_name: str, partition: int) -> None:
         self._data.setdefault((operator_name, partition), {})

--- a/styx-package/styx/local_runner/runner.py
+++ b/styx-package/styx/local_runner/runner.py
@@ -116,26 +116,33 @@ class LocalStyxRunner:
         function_name: str,
         params: tuple,
     ) -> object:
-        """Core execution: create context, run function, DFS-execute chains."""
+        """Core execution: create context, run function, DFS-execute chains.
+
+        Acquires a per-key lock so concurrent send_event calls on the
+        same key are serialized.  The lock is released *before* chained
+        remote calls execute, preventing deadlocks on cycles (e.g.
+        concurrent transfer A->B and B->A).
+        """
         operator = self._graph.nodes[operator_name]
         partition = operator.which_partition(key)
-
-        # Look up registered function
         func = operator.functions[function_name]
 
-        # Create local context
-        ctx = LocalStatefulFunction(
-            key=key,
-            operator_name=operator_name,
-            partition=partition,
-            state=self._state,
-        )
+        lock = self._state.key_lock(operator_name, key)
 
-        # Execute user function
-        result = await func(ctx, *params)
+        # Hold the lock while executing the function (get/put are protected).
+        # Release before chaining to avoid deadlocks.
+        async with lock:
+            ctx = LocalStatefulFunction(
+                key=key,
+                operator_name=operator_name,
+                partition=partition,
+                state=self._state,
+            )
+            result = await func(ctx, *params)
+            pending_chains = ctx.drain_remote_calls()
 
-        # DFS-execute any chained remote calls
-        for chain_op, chain_func, chain_key, chain_params in ctx.drain_remote_calls():
+        # DFS-execute chained calls outside the lock
+        for chain_op, chain_func, chain_key, chain_params in pending_chains:
             await self._execute_function(chain_op, chain_key, chain_func, chain_params)
 
         return result

--- a/styx-package/styx/local_runner/runner.py
+++ b/styx-package/styx/local_runner/runner.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from styx.local_runner.local_context import LocalStatefulFunction
+from styx.local_runner.local_state import LocalOperatorState
+
+if TYPE_CHECKING:
+    from styx.common.stateflow_graph import StateflowGraph
+    from styx.common.types import K
+
+
+class LocalStyxRunner:
+    """In-process sequential executor for Styx stateful functions.
+
+    Runs user-defined functions against a plain dict-backed state
+    with no infrastructure dependencies. Useful for debugging and
+    validating function logic before deploying to a full Styx cluster.
+
+    Note: This runner does NOT provide transactional semantics,
+    conflict detection, or epoch-based execution. See the README
+    for known limitations.
+    """
+
+    def __init__(self, graph: StateflowGraph) -> None:
+        self._graph = graph
+        self._state = LocalOperatorState()
+        # Initialize all partitions for all operators
+        for operator_name, operator in graph:
+            for partition in range(operator.n_partitions):
+                self._state.init_partition(operator_name, partition)
+
+    def init_data(self, operator_name: str, key_value_pairs: dict) -> None:
+        """Pre-populate state for an operator, auto-partitioning keys.
+
+        Args:
+            operator_name: Name of the operator to populate.
+            key_value_pairs: Mapping of keys to values.
+        """
+        operator = self._graph.nodes[operator_name]
+        for key, value in key_value_pairs.items():
+            partition = operator.which_partition(key)
+            self._state.put(key, value, operator_name, partition)
+
+    async def send_event(
+        self,
+        operator_name: str,
+        key: K,
+        function: str,
+        params: tuple = (),
+    ) -> object:
+        """Execute a single function call and return its result.
+
+        Chained call_remote_async calls are executed depth-first
+        after the function returns.
+
+        Args:
+            operator_name: Target operator name.
+            key: The key for this invocation.
+            function: Name of the registered function to call.
+            params: Additional parameters passed to the function.
+
+        Returns:
+            The return value of the user function.
+        """
+        return await self._execute_function(operator_name, key, function, params)
+
+    def send_event_sync(
+        self,
+        operator_name: str,
+        key: K,
+        function: str,
+        params: tuple = (),
+    ) -> object:
+        """Synchronous wrapper around send_event.
+
+        Uses asyncio.run(), so it cannot be called from within
+        an already-running event loop (e.g. Jupyter, pytest-asyncio).
+        """
+        return asyncio.run(self.send_event(operator_name, key, function, params))
+
+    async def send_batch(
+        self,
+        events: list[tuple[str, K, str, tuple]],
+    ) -> list[object]:
+        """Execute multiple events sequentially.
+
+        Args:
+            events: List of (operator_name, key, function, params) tuples.
+
+        Returns:
+            List of results, one per event.
+        """
+        results = []
+        for operator_name, key, function, params in events:
+            result = await self._execute_function(operator_name, key, function, params)
+            results.append(result)
+        return results
+
+    def get_state(self, operator_name: str) -> dict:
+        """Return merged state across all partitions for an operator.
+
+        Useful for debugging and assertions.
+        """
+        operator = self._graph.nodes[operator_name]
+        merged = {}
+        for partition in range(operator.n_partitions):
+            merged.update(self._state.get_all(operator_name, partition))
+        return merged
+
+    async def _execute_function(
+        self,
+        operator_name: str,
+        key: K,
+        function_name: str,
+        params: tuple,
+    ) -> object:
+        """Core execution: create context, run function, DFS-execute chains."""
+        operator = self._graph.nodes[operator_name]
+        partition = operator.which_partition(key)
+
+        # Look up registered function
+        func = operator.functions[function_name]
+
+        # Create local context
+        ctx = LocalStatefulFunction(
+            key=key,
+            operator_name=operator_name,
+            partition=partition,
+            state=self._state,
+        )
+
+        # Execute user function
+        result = await func(ctx, *params)
+
+        # DFS-execute any chained remote calls
+        for chain_op, chain_func, chain_key, chain_params in ctx.drain_remote_calls():
+            await self._execute_function(chain_op, chain_key, chain_func, chain_params)
+
+        return result

--- a/tests/unit/styx_package/test_local_runner.py
+++ b/tests/unit/styx_package/test_local_runner.py
@@ -1,0 +1,366 @@
+import pytest
+
+from styx.common.local_state_backends import LocalStateBackend
+from styx.common.operator import Operator
+from styx.common.stateflow_graph import StateflowGraph
+from styx.local_runner import LocalStyxRunner
+from styx.local_runner.local_context import LocalStatefulFunction
+from styx.local_runner.local_state import LocalOperatorState
+
+
+# ---------------------------------------------------------------------------
+# Helpers: reusable graph + function definitions
+# ---------------------------------------------------------------------------
+
+
+def _make_kv_graph():
+    """Single-operator graph with read/write/insert functions."""
+    g = StateflowGraph("test", operator_state_backend=LocalStateBackend.DICT)
+    op = Operator("kv", n_partitions=4)
+
+    @op.register
+    async def read(ctx):
+        return ctx.key, ctx.get()
+
+    @op.register
+    async def write(ctx, value):
+        ctx.put(value)
+        return ctx.key, value
+
+    @op.register
+    async def insert(ctx, value):
+        ctx.put(value)
+
+    @op.register
+    async def read_data(ctx):
+        return ctx.data
+
+    g.add_operator(op)
+    return g
+
+
+def _make_transfer_graph():
+    """Single-operator graph with transfer chain."""
+    g = StateflowGraph("transfer-test", operator_state_backend=LocalStateBackend.DICT)
+    op = Operator("accounts", n_partitions=2)
+
+    @op.register
+    async def transfer(ctx, to_key, amount):
+        balance = ctx.get()
+        balance -= amount
+        ctx.put(balance)
+        ctx.call_remote_async("accounts", "credit", key=to_key, params=(amount,))
+        return ctx.key, balance
+
+    @op.register
+    async def credit(ctx, amount):
+        balance = ctx.get() or 0
+        balance += amount
+        ctx.put(balance)
+        return ctx.key, balance
+
+    g.add_operator(op)
+    return g
+
+
+def _make_multi_operator_graph():
+    """Two-operator graph for cross-operator chaining."""
+    g = StateflowGraph("multi-op", operator_state_backend=LocalStateBackend.DICT)
+
+    orders = Operator("orders", n_partitions=2)
+    inventory = Operator("inventory", n_partitions=2)
+
+    @orders.register
+    async def place_order(ctx, item_key, quantity):
+        ctx.put({"item": item_key, "qty": quantity, "status": "placed"})
+        ctx.call_remote_async("inventory", "deduct", key=item_key, params=(quantity,))
+        return ctx.key
+
+    @inventory.register
+    async def deduct(ctx, quantity):
+        stock = ctx.get() or 0
+        stock -= quantity
+        ctx.put(stock)
+
+    g.add_operator(orders)
+    g.add_operator(inventory)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# LocalOperatorState unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocalOperatorState:
+    def test_init_partition_and_get(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        assert state.get("missing", "op", 0) is None
+
+    def test_put_and_get(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        state.put("k1", 42, "op", 0)
+        assert state.get("k1", "op", 0) == 42
+
+    def test_get_all(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        state.put("a", 1, "op", 0)
+        state.put("b", 2, "op", 0)
+        assert state.get_all("op", 0) == {"a": 1, "b": 2}
+
+    def test_get_all_returns_copy(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        state.put("a", 1, "op", 0)
+        copy = state.get_all("op", 0)
+        copy["a"] = 999
+        assert state.get("a", "op", 0) == 1
+
+    def test_batch_insert(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        state.batch_insert({"x": 10, "y": 20}, "op", 0)
+        assert state.get("x", "op", 0) == 10
+        assert state.get("y", "op", 0) == 20
+
+    def test_separate_partitions(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        state.init_partition("op", 1)
+        state.put("k", "val0", "op", 0)
+        state.put("k", "val1", "op", 1)
+        assert state.get("k", "op", 0) == "val0"
+        assert state.get("k", "op", 1) == "val1"
+
+    def test_separate_operators(self):
+        state = LocalOperatorState()
+        state.init_partition("a", 0)
+        state.init_partition("b", 0)
+        state.put("k", "from_a", "a", 0)
+        state.put("k", "from_b", "b", 0)
+        assert state.get("k", "a", 0) == "from_a"
+        assert state.get("k", "b", 0) == "from_b"
+
+
+# ---------------------------------------------------------------------------
+# LocalStatefulFunction unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocalStatefulFunction:
+    def test_key_property(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        ctx = LocalStatefulFunction(key=42, operator_name="op", partition=0, state=state)
+        assert ctx.key == 42
+
+    def test_get_put(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        ctx = LocalStatefulFunction(key="k", operator_name="op", partition=0, state=state)
+        assert ctx.get() is None
+        ctx.put("hello")
+        assert ctx.get() == "hello"
+
+    def test_data_property(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        state.put("a", 1, "op", 0)
+        state.put("b", 2, "op", 0)
+        ctx = LocalStatefulFunction(key="a", operator_name="op", partition=0, state=state)
+        assert ctx.data == {"a": 1, "b": 2}
+
+    def test_batch_insert(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        ctx = LocalStatefulFunction(key="k", operator_name="op", partition=0, state=state)
+        ctx.batch_insert({"x": 10, "y": 20})
+        assert state.get("x", "op", 0) == 10
+
+    def test_call_remote_async_and_drain(self):
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        ctx = LocalStatefulFunction(key="k", operator_name="op", partition=0, state=state)
+        ctx.call_remote_async("target_op", "func_a", key=1, params=(42,))
+        ctx.call_remote_async("target_op", "func_b", key=2)
+        calls = ctx.drain_remote_calls()
+        assert len(calls) == 2
+        assert calls[0] == ("target_op", "func_a", 1, (42,))
+        assert calls[1] == ("target_op", "func_b", 2, ())
+        # drain clears the queue
+        assert ctx.drain_remote_calls() == []
+
+    def test_call_remote_async_type_function_name(self):
+        """When function_name is a type, its __name__ should be used."""
+        state = LocalOperatorState()
+        state.init_partition("op", 0)
+        ctx = LocalStatefulFunction(key="k", operator_name="op", partition=0, state=state)
+
+        class MyFunc:
+            pass
+
+        ctx.call_remote_async("op", MyFunc, key=1)
+        calls = ctx.drain_remote_calls()
+        assert calls[0][1] == "MyFunc"
+
+
+# ---------------------------------------------------------------------------
+# LocalStyxRunner integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocalStyxRunnerBasics:
+    async def test_init_data_and_read(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("kv", {0: "a", 1: "b", 2: "c"})
+
+        result = await runner.send_event("kv", key=0, function="read")
+        assert result == (0, "a")
+
+    async def test_write_and_read(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+
+        await runner.send_event("kv", key=5, function="write", params=(100,))
+        result = await runner.send_event("kv", key=5, function="read")
+        assert result == (5, 100)
+
+    async def test_insert_no_return(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+
+        result = await runner.send_event("kv", key=10, function="insert", params=("val",))
+        assert result is None
+        state = runner.get_state("kv")
+        assert state[10] == "val"
+
+    async def test_read_data_property(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+        # Put two keys that land in the same partition
+        # We use key 0 and check its partition data
+        runner.init_data("kv", {0: "zero"})
+        result = await runner.send_event("kv", key=0, function="read_data")
+        assert 0 in result
+        assert result[0] == "zero"
+
+
+class TestLocalStyxRunnerChaining:
+    async def test_transfer_chain(self):
+        g = _make_transfer_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("accounts", {0: 1000, 1: 500})
+
+        result = await runner.send_event("accounts", key=0, function="transfer", params=(1, 100))
+        assert result == (0, 900)
+
+        state = runner.get_state("accounts")
+        assert state[0] == 900
+        assert state[1] == 600
+
+    async def test_multi_transfer(self):
+        g = _make_transfer_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("accounts", {0: 1000, 1: 500})
+
+        await runner.send_event("accounts", key=0, function="transfer", params=(1, 100))
+        await runner.send_event("accounts", key=1, function="transfer", params=(0, 50))
+
+        state = runner.get_state("accounts")
+        assert state[0] == 950  # 1000 - 100 + 50
+        assert state[1] == 550  # 500 + 100 - 50
+
+
+class TestLocalStyxRunnerMultiOperator:
+    async def test_cross_operator_chain(self):
+        g = _make_multi_operator_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("inventory", {42: 100})
+
+        order_key = await runner.send_event("orders", key=1, function="place_order", params=(42, 5))
+        assert order_key == 1
+
+        # Check order was placed
+        order_state = runner.get_state("orders")
+        assert order_state[1] == {"item": 42, "qty": 5, "status": "placed"}
+
+        # Check inventory was deducted
+        inv_state = runner.get_state("inventory")
+        assert inv_state[42] == 95
+
+
+class TestLocalStyxRunnerErrorHandling:
+    async def test_user_function_raises(self):
+        g = StateflowGraph("err", operator_state_backend=LocalStateBackend.DICT)
+        op = Operator("fail", n_partitions=1)
+
+        @op.register
+        async def boom(ctx):
+            raise ValueError("something went wrong")
+
+        g.add_operator(op)
+        runner = LocalStyxRunner(graph=g)
+
+        with pytest.raises(ValueError, match="something went wrong"):
+            await runner.send_event("fail", key=0, function="boom")
+
+    async def test_unknown_function_raises(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+
+        with pytest.raises(KeyError):
+            await runner.send_event("kv", key=0, function="nonexistent")
+
+    async def test_unknown_operator_raises(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+
+        with pytest.raises(KeyError):
+            await runner.send_event("nonexistent", key=0, function="read")
+
+
+class TestLocalStyxRunnerGetState:
+    async def test_get_state_merges_partitions(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("kv", {0: "a", 1: "b", 2: "c", 3: "d"})
+
+        state = runner.get_state("kv")
+        assert state == {0: "a", 1: "b", 2: "c", 3: "d"}
+
+    async def test_get_state_empty(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+        assert runner.get_state("kv") == {}
+
+
+class TestLocalStyxRunnerBatch:
+    async def test_send_batch(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("kv", {0: "x", 1: "y"})
+
+        results = await runner.send_batch([
+            ("kv", 0, "read", ()),
+            ("kv", 1, "read", ()),
+            ("kv", 2, "write", (99,)),
+        ])
+
+        assert results[0] == (0, "x")
+        assert results[1] == (1, "y")
+        assert results[2] == (2, 99)
+        assert runner.get_state("kv")[2] == 99
+
+
+class TestLocalStyxRunnerSync:
+    def test_send_event_sync(self):
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("kv", {42: "hello"})
+
+        result = runner.send_event_sync("kv", key=42, function="read")
+        assert result == (42, "hello")

--- a/tests/unit/styx_package/test_local_runner.py
+++ b/tests/unit/styx_package/test_local_runner.py
@@ -1,12 +1,10 @@
 import pytest
-
 from styx.common.local_state_backends import LocalStateBackend
 from styx.common.operator import Operator
 from styx.common.stateflow_graph import StateflowGraph
 from styx.local_runner import LocalStyxRunner
 from styx.local_runner.local_context import LocalStatefulFunction
 from styx.local_runner.local_state import LocalOperatorState
-
 
 # ---------------------------------------------------------------------------
 # Helpers: reusable graph + function definitions
@@ -300,7 +298,8 @@ class TestLocalStyxRunnerErrorHandling:
 
         @op.register
         async def boom(ctx):
-            raise ValueError("something went wrong")
+            msg = "something went wrong"
+            raise ValueError(msg)
 
         g.add_operator(op)
         runner = LocalStyxRunner(graph=g)
@@ -344,11 +343,13 @@ class TestLocalStyxRunnerBatch:
         runner = LocalStyxRunner(graph=g)
         runner.init_data("kv", {0: "x", 1: "y"})
 
-        results = await runner.send_batch([
-            ("kv", 0, "read", ()),
-            ("kv", 1, "read", ()),
-            ("kv", 2, "write", (99,)),
-        ])
+        results = await runner.send_batch(
+            [
+                ("kv", 0, "read", ()),
+                ("kv", 1, "read", ()),
+                ("kv", 2, "write", (99,)),
+            ]
+        )
 
         assert results[0] == (0, "x")
         assert results[1] == (1, "y")

--- a/tests/unit/styx_package/test_local_runner.py
+++ b/tests/unit/styx_package/test_local_runner.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from styx.common.local_state_backends import LocalStateBackend
 from styx.common.operator import Operator
@@ -365,3 +367,107 @@ class TestLocalStyxRunnerSync:
 
         result = runner.send_event_sync("kv", key=42, function="read")
         assert result == (42, "hello")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocalStyxRunnerConcurrency:
+    async def test_concurrent_writes_different_keys(self):
+        """Concurrent writes to different keys should all succeed."""
+        g = _make_kv_graph()
+        runner = LocalStyxRunner(graph=g)
+
+        await asyncio.gather(
+            *(runner.send_event("kv", key=i, function="write", params=(i * 10,)) for i in range(50))
+        )
+
+        state = runner.get_state("kv")
+        for i in range(50):
+            assert state[i] == i * 10
+
+    async def test_concurrent_writes_same_key(self):
+        """Concurrent writes to the same key should serialize correctly."""
+        g = StateflowGraph("counter", operator_state_backend=LocalStateBackend.DICT)
+        op = Operator("c", n_partitions=1)
+
+        @op.register
+        async def increment(ctx):
+            val = ctx.get() or 0
+            val += 1
+            ctx.put(val)
+            return val
+
+        g.add_operator(op)
+        runner = LocalStyxRunner(graph=g)
+
+        n = 100
+        await asyncio.gather(
+            *(runner.send_event("c", key=0, function="increment") for _ in range(n))
+        )
+
+        state = runner.get_state("c")
+        assert state[0] == n
+
+    async def test_concurrent_transfers_conserve_total(self):
+        """Concurrent transfers must conserve the total money supply."""
+        g = _make_transfer_graph()
+        runner = LocalStyxRunner(graph=g)
+        n_accounts = 20
+        initial = 1000
+        runner.init_data("accounts", {i: initial for i in range(n_accounts)})
+
+        # Generate diverse pairs: each source key appears at most a few times
+        n_transfers = 100
+        pairs = [(i % n_accounts, (i + 1 + i // n_accounts) % n_accounts) for i in range(n_transfers)]
+
+        await asyncio.gather(
+            *(
+                runner.send_event("accounts", key=a, function="transfer", params=(b, 1))
+                for a, b in pairs
+            )
+        )
+
+        state = runner.get_state("accounts")
+        total = sum(state.values())
+        assert total == n_accounts * initial
+
+    async def test_concurrent_cross_operator_chains(self):
+        """Concurrent cross-operator chains should not corrupt state."""
+        g = _make_multi_operator_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("inventory", {i: 1000 for i in range(10)})
+
+        # 50 concurrent orders, each deducting 1 from a different item
+        await asyncio.gather(
+            *(
+                runner.send_event(
+                    "orders", key=i, function="place_order", params=(i % 10, 1)
+                )
+                for i in range(50)
+            )
+        )
+
+        inv_state = runner.get_state("inventory")
+        # Each item 0-9 should have been deducted 5 times (50 orders / 10 items)
+        for item in range(10):
+            assert inv_state[item] == 1000 - 5
+
+    async def test_concurrent_bidirectional_transfers_no_deadlock(self):
+        """Concurrent A->B and B->A transfers must not deadlock."""
+        g = _make_transfer_graph()
+        runner = LocalStyxRunner(graph=g)
+        runner.init_data("accounts", {0: 1000, 1: 1000})
+
+        # Many concurrent transfers in both directions
+        tasks = []
+        for _ in range(50):
+            tasks.append(runner.send_event("accounts", key=0, function="transfer", params=(1, 1)))
+            tasks.append(runner.send_event("accounts", key=1, function="transfer", params=(0, 1)))
+
+        await asyncio.gather(*tasks)
+
+        state = runner.get_state("accounts")
+        assert state[0] + state[1] == 2000

--- a/tests/unit/styx_package/test_local_runner.py
+++ b/tests/unit/styx_package/test_local_runner.py
@@ -380,9 +380,7 @@ class TestLocalStyxRunnerConcurrency:
         g = _make_kv_graph()
         runner = LocalStyxRunner(graph=g)
 
-        await asyncio.gather(
-            *(runner.send_event("kv", key=i, function="write", params=(i * 10,)) for i in range(50))
-        )
+        await asyncio.gather(*(runner.send_event("kv", key=i, function="write", params=(i * 10,)) for i in range(50)))
 
         state = runner.get_state("kv")
         for i in range(50):
@@ -404,9 +402,7 @@ class TestLocalStyxRunnerConcurrency:
         runner = LocalStyxRunner(graph=g)
 
         n = 100
-        await asyncio.gather(
-            *(runner.send_event("c", key=0, function="increment") for _ in range(n))
-        )
+        await asyncio.gather(*(runner.send_event("c", key=0, function="increment") for _ in range(n)))
 
         state = runner.get_state("c")
         assert state[0] == n
@@ -417,17 +413,14 @@ class TestLocalStyxRunnerConcurrency:
         runner = LocalStyxRunner(graph=g)
         n_accounts = 20
         initial = 1000
-        runner.init_data("accounts", {i: initial for i in range(n_accounts)})
+        runner.init_data("accounts", dict.fromkeys(range(n_accounts), initial))
 
         # Generate diverse pairs: each source key appears at most a few times
         n_transfers = 100
         pairs = [(i % n_accounts, (i + 1 + i // n_accounts) % n_accounts) for i in range(n_transfers)]
 
         await asyncio.gather(
-            *(
-                runner.send_event("accounts", key=a, function="transfer", params=(b, 1))
-                for a, b in pairs
-            )
+            *(runner.send_event("accounts", key=a, function="transfer", params=(b, 1)) for a, b in pairs)
         )
 
         state = runner.get_state("accounts")
@@ -438,16 +431,11 @@ class TestLocalStyxRunnerConcurrency:
         """Concurrent cross-operator chains should not corrupt state."""
         g = _make_multi_operator_graph()
         runner = LocalStyxRunner(graph=g)
-        runner.init_data("inventory", {i: 1000 for i in range(10)})
+        runner.init_data("inventory", dict.fromkeys(range(10), 1000))
 
         # 50 concurrent orders, each deducting 1 from a different item
         await asyncio.gather(
-            *(
-                runner.send_event(
-                    "orders", key=i, function="place_order", params=(i % 10, 1)
-                )
-                for i in range(50)
-            )
+            *(runner.send_event("orders", key=i, function="place_order", params=(i % 10, 1)) for i in range(50))
         )
 
         inv_state = runner.get_state("inventory")


### PR DESCRIPTION
Aims to address #23.

## Summary

  - Adds `LocalStyxRunner` — an in-process executor that runs Styx stateful functions against a dict-backed state with no Kafka, S3, coordinator, or workers required
  - Supports concurrent execution via `asyncio.gather()` with per-key locking to protect state
  - Includes a YCSB demo (`demo/demo-local-runner/`) running concurrent transfers with money conservation validation

  ## Motivation

  Running a Styx application today requires the full stack (Kafka, S3, coordinator, workers) even for simple debugging. The local runner lets users validate function logic — `get`/`put`/chaining — in a single process
  before deploying to a cluster.

  ## What's included

  **New package: `styx-package/styx/local_runner/`**
  - `LocalStyxRunner` — main orchestrator with `send_event`, `send_event_sync`, `send_batch`, `init_data`, `get_state`
  - `LocalStatefulFunction` — duck-typed `StatefulFunction` with the same user-facing API (`key`, `data`, `get()`, `put()`, `call_remote_async()`)
  - `LocalOperatorState` — dict-backed state with per-key `asyncio.Lock` for concurrency safety
  - README documenting API, concurrency model, and known limitations vs production

  **Concurrency model:**
  - Per-key `asyncio.Lock` serializes concurrent access to the same key
  - Locks are released *before* DFS-chaining to prevent deadlocks on, for example, bidirectional transfers (A→B + B→A)

  **Demo: `demo/demo-local-runner/`**
  - Reuses YCSB operator functions from `demo/demo-ycsb/`
  - Runs 500 concurrent transfers across 100 accounts, validates total money conservation

  **Tests: `tests/unit/styx_package/test_local_runner.py`** — 32 tests covering:
  - State and context unit tests
  - Function execution, chaining, cross-operator chains
  - Error handling, batch execution, sync wrapper
  - 5 concurrency tests: parallel writes, same-key serialization, transfer conservation, cross-operator chains, bidirectional deadlock safety

  ## Known limitations (documented in README)

  - No transactional semantics, conflict detection, or epoch-based execution
  - `put()` writes are immediate (no abort/retry)
  - Chains execute DFS after parent lock release, not in epoch batches
  - No serialization round-trip — objects pass by reference
  - `LocalStatefulFunction` may drift from `StatefulFunction` if the real class changes
