### PR TITLE
Update kubefwd setup docs

### DIFF
--- a/docs/styx-docs/running-experiments.md
+++ b/docs/styx-docs/running-experiments.md
@@ -83,7 +83,7 @@ sudo visudo -f /etc/sudoers.d/kubefwd
 Add the following line, replacing `youruser` with your Linux username:
 
 ```
-youruser ALL=(ALL) NOPASSWD: /usr/local/bin/kubefwd
+youruser ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/kubefwd
 ```
 
 Verify:


### PR DESCRIPTION
When following running-experiments.md on a clean setup, deploying with minikube failed for me with:
```
...
Styx cluster is Ready.
Forwarding all services in namespace 'styx' via kubefwd...
sudo: sorry, you are not allowed to set the following environment variables: KUBECONFIG
```
This happens because the documented sudoers rule doesn't permit environment variables to be passed through to kubefwd. Changing  
`youruser ALL=(ALL) NOPASSWD: /usr/local/bin/kubefwd`
to 
`youruser ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/kubefwd`
fixes it. This PR updates the docs to reflect this case.
