### PR TITLE
Two-phase migration: minimize stop-the-world window

### DIFF
--- a/coordinator/coordinator_service.py
+++ b/coordinator/coordinator_service.py
@@ -279,12 +279,9 @@ class CoordinatorService:
             logging.info("Submitted Stateflow Graph Update to Workers")
 
     async def _start_migration(self, graph: StateflowGraph) -> None:
-        # Gracefully stop the transactional protocol in the next epoch
+        # Phase A: do NOT stop the protocol yet — workers will rehash in the background
         self.migration_in_progress = True
         await self.stop_snapshotting()
-
-        if self.aria_metadata is not None:
-            self.aria_metadata.stop_in_next_epoch()
 
         logging.warning(f"MIGRATION | START {graph}")
         await self.coordinator.update_stateflow_graph(graph)
@@ -304,21 +301,14 @@ class CoordinatorService:
     async def _handle_migration_repartitioning_done(
         self,
         _: StreamWriter,
-        data: bytes,
-        __: concurrent.futures.ProcessPoolExecutor,
+        __: bytes,
+        ___: concurrent.futures.ProcessPoolExecutor,
     ) -> None:
         mt = MessageType.MigrationRepartitioningDone
         logging.warning("Migration repartitioning done received!")
 
         async with self.networking_locks[mt]:
-            epoch_counter, t_counter, input_offsets, output_offsets = self.networking.decode_message(data)
-
-            sync_complete: bool = await self.migration_metadata.repartitioning_done(
-                epoch_counter,
-                t_counter,
-                input_offsets,
-                output_offsets,
-            )
+            sync_complete: bool = await self.migration_metadata.repartitioning_done()
 
             logging.warning(f"Migration repartitioning is complete: {sync_complete}")
 
@@ -331,12 +321,19 @@ class CoordinatorService:
     async def _handle_migration_init_done(
         self,
         _: StreamWriter,
-        __: bytes,
-        ___: concurrent.futures.ProcessPoolExecutor,
+        data: bytes,
+        __: concurrent.futures.ProcessPoolExecutor,
     ) -> None:
         mt = MessageType.MigrationInitDone
         async with self.networking_locks[mt]:
-            sync_complete: bool = await self.migration_metadata.set_empty_sync_done(mt)
+            epoch_counter, t_counter, input_offsets, output_offsets = self.networking.decode_message(data)
+
+            sync_complete: bool = await self.migration_metadata.init_done(
+                epoch_counter,
+                t_counter,
+                input_offsets,
+                output_offsets,
+            )
             logging.warning(f"MIGRATION | MigrationInitDone | {self.migration_metadata.sync_sum}")
 
             if not sync_complete:
@@ -735,21 +732,20 @@ class CoordinatorService:
                 await server.serve_forever()
 
     async def finalize_migration_repartition(self) -> None:
-        logging.warning("Sending MigrationRepartitioningDone to all workers")
+        # Now that all workers have finished rehashing, stop the protocol
+        if self.aria_metadata is not None:
+            self.aria_metadata.stop_in_next_epoch()
+
+        logging.warning("Sending MigrationRepartitioningDone to all workers (protocol will stop)")
         async with asyncio.TaskGroup() as tg:
             for worker in self.coordinator.worker_pool.get_participating_workers():
                 tg.create_task(
                     self.protocol_networking.send_message(
                         worker.worker_ip,
                         worker.worker_port,
-                        msg=(
-                            self.migration_metadata.epoch_counter,
-                            self.migration_metadata.t_counter,
-                            self.migration_metadata.input_offsets,
-                            self.migration_metadata.output_offsets,
-                        ),
+                        msg=b"",
                         msg_type=MessageType.MigrationRepartitioningDone,
-                        serializer=Serializer.MSGPACK,
+                        serializer=Serializer.NONE,
                     ),
                 )
 
@@ -761,9 +757,14 @@ class CoordinatorService:
                     self.protocol_networking.send_message(
                         worker.worker_ip,
                         worker.worker_port,
-                        msg=b"",
+                        msg=(
+                            self.migration_metadata.epoch_counter,
+                            self.migration_metadata.t_counter,
+                            self.migration_metadata.input_offsets,
+                            self.migration_metadata.output_offsets,
+                        ),
                         msg_type=MessageType.MigrationDone,
-                        serializer=Serializer.NONE,
+                        serializer=Serializer.MSGPACK,
                     ),
                 )
 

--- a/coordinator/coordinator_service.py
+++ b/coordinator/coordinator_service.py
@@ -732,9 +732,13 @@ class CoordinatorService:
                 await server.serve_forever()
 
     async def finalize_migration_repartition(self) -> None:
-        # Now that all workers have finished rehashing, stop the protocol
-        if self.aria_metadata is not None:
-            self.aria_metadata.stop_in_next_epoch()
+        # Acquire the SyncCleanup lock to prevent a race where
+        # _handle_sync_cleanup reads stop_next_epoch=False (before we set it),
+        # sends stop_gracefully=False, then cleanup() resets the flag — which
+        # would silently consume the stop request we are about to issue.
+        async with self.networking_locks[MessageType.SyncCleanup]:
+            if self.aria_metadata is not None:
+                self.aria_metadata.stop_in_next_epoch()
 
         logging.warning("Sending MigrationRepartitioningDone to all workers (protocol will stop)")
         async with asyncio.TaskGroup() as tg:

--- a/coordinator/migration_metadata.py
+++ b/coordinator/migration_metadata.py
@@ -21,15 +21,22 @@ class MigrationMetadata:
     def check_sum(self, msg_type: MessageType) -> bool:
         return self.sync_sum[msg_type] == self.n_workers
 
-    async def repartitioning_done(
+    async def repartitioning_done(self) -> bool:
+        """Barrier-only: no counters collected here (moved to init_done)."""
+        async with self.lock:
+            self.sync_sum[MessageType.MigrationRepartitioningDone] += 1
+            return self.check_sum(MessageType.MigrationRepartitioningDone)
+
+    async def init_done(
         self,
         epoch_counter: int,
         t_counter: int,
         input_offsets: dict[OperatorPartition, int],
         output_offsets: dict[OperatorPartition, int],
     ) -> bool:
+        """Collect epoch/offset counters from each worker during Phase B."""
         async with self.lock:
-            self.sync_sum[MessageType.MigrationRepartitioningDone] += 1
+            self.sync_sum[MessageType.MigrationInitDone] += 1
             for operator_partition, pio in input_offsets.items():
                 self.input_offsets[operator_partition] = max(
                     pio,
@@ -42,7 +49,7 @@ class MigrationMetadata:
                 )
             self.epoch_counter = max(epoch_counter, self.epoch_counter)
             self.t_counter = max(t_counter, self.t_counter)
-            return self.check_sum(MessageType.MigrationRepartitioningDone)
+            return self.check_sum(MessageType.MigrationInitDone)
 
     async def set_empty_sync_done(self, msg_type: MessageType) -> bool:
         async with self.lock:
@@ -52,7 +59,7 @@ class MigrationMetadata:
     async def cleanup(self, msg_type: MessageType) -> None:
         async with self.lock:
             self.sync_sum[msg_type] = 0
-            if msg_type == MessageType.MigrationRepartitioningDone:
+            if msg_type == MessageType.MigrationInitDone:
                 self.epoch_counter = -1
                 self.t_counter = -1
                 self.input_offsets.clear()

--- a/tests/unit/coordinator/test_migration_metadata.py
+++ b/tests/unit/coordinator/test_migration_metadata.py
@@ -40,61 +40,85 @@ class TestCheckSum:
 
 
 # ---------------------------------------------------------------------------
-# repartitioning_done
+# repartitioning_done (barrier-only, no counters)
 # ---------------------------------------------------------------------------
 
 
 class TestRepartitioningDone:
     def test_returns_false_before_all_workers(self):
         meta = MigrationMetadata(n_workers=3)
-        result = run(meta.repartitioning_done(1, 100, {("op", 0): 5}, {("op", 0): 3}))
+        result = run(meta.repartitioning_done())
         assert result is False
 
     def test_returns_true_when_all_workers_reported(self):
         meta = MigrationMetadata(n_workers=2)
-        run(meta.repartitioning_done(1, 10, {}, {}))
-        result = run(meta.repartitioning_done(5, 20, {}, {}))
+        run(meta.repartitioning_done())
+        result = run(meta.repartitioning_done())
+        assert result is True
+
+    def test_increments_sync_sum(self):
+        meta = MigrationMetadata(n_workers=3)
+        run(meta.repartitioning_done())
+        run(meta.repartitioning_done())
+        assert meta.sync_sum[MessageType.MigrationRepartitioningDone] == 2
+
+
+# ---------------------------------------------------------------------------
+# init_done (collects counters)
+# ---------------------------------------------------------------------------
+
+
+class TestInitDone:
+    def test_returns_false_before_all_workers(self):
+        meta = MigrationMetadata(n_workers=3)
+        result = run(meta.init_done(1, 100, {("op", 0): 5}, {("op", 0): 3}))
+        assert result is False
+
+    def test_returns_true_when_all_workers_reported(self):
+        meta = MigrationMetadata(n_workers=2)
+        run(meta.init_done(1, 10, {}, {}))
+        result = run(meta.init_done(5, 20, {}, {}))
         assert result is True
 
     def test_input_offsets_takes_max(self):
         meta = MigrationMetadata(n_workers=2)
-        run(meta.repartitioning_done(1, 0, {("op", 0): 10}, {}))
-        run(meta.repartitioning_done(5, 0, {("op", 0): 5}, {}))
+        run(meta.init_done(1, 0, {("op", 0): 10}, {}))
+        run(meta.init_done(5, 0, {("op", 0): 5}, {}))
         assert meta.input_offsets[("op", 0)] == 10
 
     def test_output_offsets_takes_max(self):
         meta = MigrationMetadata(n_workers=2)
-        run(meta.repartitioning_done(1, 0, {}, {("op", 0): 3}))
-        run(meta.repartitioning_done(5, 0, {}, {("op", 0): 7}))
+        run(meta.init_done(1, 0, {}, {("op", 0): 3}))
+        run(meta.init_done(5, 0, {}, {("op", 0): 7}))
         assert meta.output_offsets[("op", 0)] == 7
 
     def test_epoch_counter_takes_max(self):
         meta = MigrationMetadata(n_workers=2)
-        run(meta.repartitioning_done(100, 0, {}, {}))
-        run(meta.repartitioning_done(50, 0, {}, {}))
+        run(meta.init_done(100, 0, {}, {}))
+        run(meta.init_done(50, 0, {}, {}))
         assert meta.epoch_counter == 100
 
     def test_t_counter_takes_max(self):
         meta = MigrationMetadata(n_workers=2)
-        run(meta.repartitioning_done(1, 0, {}, {}))
-        run(meta.repartitioning_done(5, 0, {}, {}))
+        run(meta.init_done(1, 0, {}, {}))
+        run(meta.init_done(5, 0, {}, {}))
         # t_counter passed as second arg; both calls pass 0 → max stays 0
         # (t_counter starts at -1, max(0, -1) = 0)
         assert meta.t_counter == 0
 
     def test_multiple_partitions_merged(self):
         meta = MigrationMetadata(n_workers=2)
-        run(meta.repartitioning_done(1, 0, {("op", 0): 10, ("op", 1): 20}, {}))
-        run(meta.repartitioning_done(5, 0, {("op", 2): 30}, {}))
+        run(meta.init_done(1, 0, {("op", 0): 10, ("op", 1): 20}, {}))
+        run(meta.init_done(5, 0, {("op", 2): 30}, {}))
         assert ("op", 0) in meta.input_offsets
         assert ("op", 1) in meta.input_offsets
         assert ("op", 2) in meta.input_offsets
 
     def test_increments_sync_sum(self):
         meta = MigrationMetadata(n_workers=3)
-        run(meta.repartitioning_done(1, 0, {}, {}))
-        run(meta.repartitioning_done(2, 0, {}, {}))
-        assert meta.sync_sum[MessageType.MigrationRepartitioningDone] == 2
+        run(meta.init_done(1, 0, {}, {}))
+        run(meta.init_done(2, 0, {}, {}))
+        assert meta.sync_sum[MessageType.MigrationInitDone] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -146,13 +170,13 @@ class TestCleanup:
         run(meta.cleanup(MessageType.MigrationDone))
         assert meta.sync_sum[MessageType.MigrationRepartitioningDone] == 1
 
-    def test_cleanup_repartitioning_clears_offsets(self):
+    def test_cleanup_init_done_clears_offsets(self):
         meta = MigrationMetadata(n_workers=2)
         meta.input_offsets[("op", 0)] = 10
         meta.output_offsets[("op", 0)] = 5
         meta.epoch_counter = 99
         meta.t_counter = 42
-        run(meta.cleanup(MessageType.MigrationRepartitioningDone))
+        run(meta.cleanup(MessageType.MigrationInitDone))
         assert len(meta.input_offsets) == 0
         assert len(meta.output_offsets) == 0
         assert meta.epoch_counter == -1

--- a/tests/unit/worker/test_in_memory_state.py
+++ b/tests/unit/worker/test_in_memory_state.py
@@ -368,19 +368,19 @@ class TestExists:
         s.keys_to_send[OP_PART] = set()  # partition tracked but "k" not queued
         assert s.exists("k", OP, PART) is True
 
-    def test_true_when_key_queued_but_still_in_data(self):
-        # keys_to_send stores (key, new_partition) tuples; bare key comparison is always
-        # unequal to tuples, so a queued key is still "existing" until physically popped
+    def test_false_when_key_queued_for_migration(self):
+        # A key in keys_to_send is being migrated to another partition,
+        # so it should not be considered as existing locally.
         s = _state()
         s.data[OP_PART]["k"] = "v"
         s.keys_to_send[OP_PART] = {("k", 1)}
-        assert s.exists("k", OP, PART) is True
+        assert s.exists("k", OP, PART) is False
 
-    def test_false_outside_migration_context(self):
-        # exists is migration-specific: without keys_to_send it returns False
+    def test_true_outside_migration_context(self):
+        # Key exists in data without any migration context — should return True
         s = _state()
         s.data[OP_PART]["k"] = "v"
-        assert s.exists("k", OP, PART) is False
+        assert s.exists("k", OP, PART) is True
 
     def test_false_for_unknown_operator_partition(self):
         s = _state()

--- a/worker/ingress/styx_kafka_ingress.py
+++ b/worker/ingress/styx_kafka_ingress.py
@@ -101,8 +101,9 @@ class StyxKafkaIngress(BaseIngress):
                         operator_name=operator_name,
                         partition=true_partition,
                         function_name=fun_name,
+                        kafka_offset=msg.offset,
                         params=params,
-                        kafka_ingress_partition=partition,
+                        kafka_ingress_partition=msg.partition,
                     )
                     self.sequencer.sequence(run_func_payload)
                 else:

--- a/worker/operator_state/aria/in_memory_state.py
+++ b/worker/operator_state/aria/in_memory_state.py
@@ -45,11 +45,15 @@ class InMemoryOperatorState(BaseAriaState):
         new_operator_partition: OperatorPartition,
         key: K,
         old_partition: int,
-    ) -> K:
+    ) -> K | None:
         operator_name, new_partition = new_operator_partition
         operator_partition: OperatorPartition = (operator_name, old_partition)
-        data_to_send: K = self.data[operator_partition].pop(key)
-        self.keys_to_send[operator_partition].remove((key, new_partition))
+        data_to_send = self.data[operator_partition].pop(key, None)
+        if data_to_send is None:
+            # Key was already transferred via async migration batch
+            return None
+        if operator_partition in self.keys_to_send:
+            self.keys_to_send[operator_partition].discard((key, new_partition))
         return data_to_send
 
     def set_data_from_migration(
@@ -59,10 +63,14 @@ class InMemoryOperatorState(BaseAriaState):
         data: KVPairs,
     ) -> None:
         operator_partition = tuple(operator_partition)
-        self.data[operator_partition][key] = data
-        del self.remote_keys[operator_partition][key]
-        if not self.remote_keys[operator_partition]:
-            del self.remote_keys[operator_partition]
+        if data is not None:
+            self.data[operator_partition][key] = data
+        # Guard: remote_keys may not have the entry if async batch arrived
+        # before hash metadata, or if the key was already removed.
+        if operator_partition in self.remote_keys:
+            self.remote_keys[operator_partition].pop(key, None)
+            if not self.remote_keys[operator_partition]:
+                del self.remote_keys[operator_partition]
 
     def migrate_within_the_same_worker(
         self,
@@ -101,7 +109,10 @@ class InMemoryOperatorState(BaseAriaState):
             operator_name, _ = operator_partition
             while keys and c < batch_size:
                 key, new_partition = keys.pop()
-                value = self.data[operator_partition].pop(key)
+                value = self.data[operator_partition].pop(key, None)
+                if value is None:
+                    # Key was deleted between rehash and transfer — skip it
+                    continue
                 batch_to_send[(operator_name, new_partition)][key] = value
                 c += 1
             if not keys:
@@ -120,10 +131,13 @@ class InMemoryOperatorState(BaseAriaState):
     ) -> None:
         operator_partition = tuple(operator_partition)  # new partitioning
         self.data[operator_partition].update(kv_pairs)
-        for key in kv_pairs:
-            del self.remote_keys[operator_partition][key]
-        if not self.remote_keys[operator_partition]:
-            del self.remote_keys[operator_partition]
+        # Guard: remote_keys may not have entries if async batch arrived
+        # before hash metadata, or entries were already removed.
+        if operator_partition in self.remote_keys:
+            for key in kv_pairs:
+                self.remote_keys[operator_partition].pop(key, None)
+            if not self.remote_keys[operator_partition]:
+                del self.remote_keys[operator_partition]
 
     def get_worker_id_old_partition(
         self,
@@ -252,11 +266,14 @@ class InMemoryOperatorState(BaseAriaState):
         operator_partition: OperatorPartition = (operator_name, partition)
         if operator_partition not in self.data:
             return False
-        return (
-            operator_partition in self.keys_to_send
-            and key not in self.keys_to_send[operator_partition]
-            and key in self.data[operator_partition]
-        ) or self.in_remote_keys(key, operator_name, partition)
+        if key in self.data[operator_partition]:
+            # During migration: a key still in data but pending send to another
+            # partition should not be considered as belonging here.
+            if operator_partition in self.keys_to_send:
+                return not any(k == key for k, _ in self.keys_to_send[operator_partition])
+            return True
+        # During migration: key is expected to arrive from a remote worker
+        return self.in_remote_keys(key, operator_name, partition)
 
     def commit(self, aborted_from_remote: set[int]) -> set[int]:
         try:

--- a/worker/operator_state/aria/in_memory_state.py
+++ b/worker/operator_state/aria/in_memory_state.py
@@ -65,12 +65,13 @@ class InMemoryOperatorState(BaseAriaState):
         operator_partition = tuple(operator_partition)
         if data is not None:
             self.data[operator_partition][key] = data
-        # Guard: remote_keys may not have the entry if async batch arrived
-        # before hash metadata, or if the key was already removed.
-        if operator_partition in self.remote_keys:
-            self.remote_keys[operator_partition].pop(key, None)
-            if not self.remote_keys[operator_partition]:
-                del self.remote_keys[operator_partition]
+            # Only remove from remote_keys when we actually received the data.
+            # A None response means the async migration batch already transferred
+            # this key — the batch will arrive and set it via set_batch_data_from_migration.
+            if operator_partition in self.remote_keys:
+                self.remote_keys[operator_partition].pop(key, None)
+                if not self.remote_keys[operator_partition]:
+                    del self.remote_keys[operator_partition]
 
     def migrate_within_the_same_worker(
         self,

--- a/worker/transactional_protocols/aria.py
+++ b/worker/transactional_protocols/aria.py
@@ -126,7 +126,7 @@ class AriaProtocol(BaseTransactionalProtocol):
 
         self.egress: StyxKafkaBatchEgress = StyxKafkaBatchEgress(
             output_offsets,
-            restart_after_recovery,
+            restart_after_recovery or restart_after_migration,
         )
         # Primary task used for processing
         self.function_scheduler_task: asyncio.Task | None = None
@@ -478,11 +478,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             f"Write to WAL successful at epoch: {self.sequencer.epoch_counter}",
         )
         return start_wal, end_wal
-
-    async def send_async_migrate_batch(self) -> None:
-        if USE_ASYNC_MIGRATION and self.local_state.has_keys_to_send():
-            batch = self.local_state.get_async_migrate_batch(ASYNC_MIGRATION_BATCH_SIZE)
-            await self._send_migration_batch(batch)
 
     async def _send_migration_batch(
         self,

--- a/worker/transactional_protocols/aria.py
+++ b/worker/transactional_protocols/aria.py
@@ -131,6 +131,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         # Primary task used for processing
         self.function_scheduler_task: asyncio.Task | None = None
         self.communication_task: asyncio.Task | None = None
+        self.migration_sender_task: asyncio.Task | None = None
 
         self.max_t_counter: int = -1
         self.total_processed_seq_size: int = -1
@@ -204,9 +205,13 @@ class AriaProtocol(BaseTransactionalProtocol):
         await self.snapshotting_networking_manager.close_all_connections()
         self.function_scheduler_task.cancel()
         self.communication_task.cancel()
+        if self.migration_sender_task is not None:
+            self.migration_sender_task.cancel()
         try:
             await self.function_scheduler_task
             await self.communication_task
+            if self.migration_sender_task is not None:
+                await self.migration_sender_task
         except asyncio.CancelledError:
             logging.warning("Protocol coroutines stopped")
         logging.info(f"Active tasks: {asyncio.all_tasks()}")
@@ -216,6 +221,8 @@ class AriaProtocol(BaseTransactionalProtocol):
     def start(self) -> None:
         self.function_scheduler_task = asyncio.create_task(self.function_scheduler())
         self.communication_task = asyncio.create_task(self.communication_protocol())
+        if self.migrating_state and USE_ASYNC_MIGRATION:
+            self.migration_sender_task = asyncio.create_task(self._continuous_migration_sender())
         logging.warning(
             f"Aria protocol started with operator partitions: {list(self.registered_operators.keys())}",
         )
@@ -449,6 +456,12 @@ class AriaProtocol(BaseTransactionalProtocol):
 
         async with self.networking_locks[mt]:
             self.local_state.set_batch_data_from_migration(operator_partition, batch)
+            # Unblock any transactions waiting for these keys via RequestRemoteKey
+            op = tuple(operator_partition)
+            if op in self.networking.wait_remote_key_event:
+                for key in batch:
+                    if key in self.networking.wait_remote_key_event.get(op, {}):
+                        self.networking.wait_remote_key_event[op][key].set()
 
     async def _write_to_wal(self, sequence: list[SequencedItem]) -> tuple[float, float]:
         start_wal = timer()
@@ -469,23 +482,75 @@ class AriaProtocol(BaseTransactionalProtocol):
     async def send_async_migrate_batch(self) -> None:
         if USE_ASYNC_MIGRATION and self.local_state.has_keys_to_send():
             batch = self.local_state.get_async_migrate_batch(ASYNC_MIGRATION_BATCH_SIZE)
-            for operator_partition, k_v_pairs in batch.items():
-                operator_name, partition = operator_partition
-                worker = self.dns[operator_name][partition]
-                if worker == self.id:
-                    async with self.networking_locks[MessageType.AsyncMigration]:
-                        self.local_state.set_batch_data_from_migration(
-                            operator_partition,
-                            k_v_pairs,
-                        )
-                else:
-                    await self.networking.send_message(
+            await self._send_migration_batch(batch)
+
+    async def _send_migration_batch(
+        self,
+        batch: dict,
+    ) -> None:
+        """Send a migration batch to destination workers in parallel."""
+        send_tasks = []
+        for operator_partition, k_v_pairs in batch.items():
+            operator_name, partition = operator_partition
+            worker = self.dns[operator_name][partition]
+            if worker == self.id:
+                async with self.networking_locks[MessageType.AsyncMigration]:
+                    self.local_state.set_batch_data_from_migration(
+                        operator_partition,
+                        k_v_pairs,
+                    )
+            else:
+                send_tasks.append(
+                    self.networking.send_message(
                         worker[0],
                         worker[2],
                         msg=(operator_partition, k_v_pairs),
                         msg_type=MessageType.AsyncMigration,
                         serializer=Serializer.MSGPACK,
-                    )
+                    ),
+                )
+        if send_tasks:
+            await asyncio.gather(*send_tasks)
+
+    async def _continuous_migration_sender(self) -> None:
+        """Background coroutine that continuously sends migration batches
+        independently of epoch barriers, completing migration faster.
+
+        Completion is based only on keys_remaining_to_send() — the coordinator's
+        global barrier (all workers report MigrationDone) ensures all data is
+        fully transferred.  We do NOT check keys_remaining_to_remote() because
+        hash metadata from other workers may not have arrived yet.
+        """
+        logging.warning("MIGRATION | Continuous migration sender started")
+        try:
+            while self.migrating_state:
+                if not self.local_state.has_keys_to_send():
+                    if self.local_state.keys_remaining_to_send() == 0:
+                        self.migrating_state = False
+                        await self.networking.send_message(
+                            DISCOVERY_HOST,
+                            DISCOVERY_PORT + 1,
+                            msg=b"",
+                            msg_type=MessageType.MigrationDone,
+                            serializer=Serializer.NONE,
+                        )
+                        logging.warning(
+                            f"MIGRATION_FINISHED at epoch: {self.sequencer.epoch_counter}"
+                            f" at time: {time.time_ns() // 1_000_000}",
+                        )
+                        return
+                    # keys_to_send dict is empty but keys_remaining_to_send > 0
+                    # shouldn't normally happen, but yield and retry
+                    await asyncio.sleep(0.01)
+                    continue
+
+                batch = self.local_state.get_async_migrate_batch(ASYNC_MIGRATION_BATCH_SIZE)
+                await self._send_migration_batch(batch)
+                # Yield to event loop between batches
+                await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            logging.warning("MIGRATION | Continuous migration sender cancelled")
+            raise
 
     async def function_scheduler(self) -> None:
         await self.started.wait()
@@ -553,8 +618,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         snap_end = timer()
 
         epoch_end = timer()
-
-        await self._maybe_finish_async_migration()
 
         await self._sync_cleanup(
             sequence=sequence,
@@ -664,7 +727,6 @@ class AriaProtocol(BaseTransactionalProtocol):
                 len(sequence),
             ),
             serializer=Serializer.PICKLE,
-            send_async_migration_message=True,
         )
         end = timer()
 
@@ -729,27 +791,6 @@ class AriaProtocol(BaseTransactionalProtocol):
                 self.topic_partition_offsets[tpo_key] = payload.kafka_offset
             else:
                 self.topic_partition_offsets[tpo_key] = max(payload.kafka_offset, prev)
-
-    async def _maybe_finish_async_migration(self) -> None:
-        if not (self.migrating_state and USE_ASYNC_MIGRATION):
-            return
-
-        migration_progress = self.local_state.keys_remaining_to_send()
-        logging.debug(f"Keys to be sent: {migration_progress}")
-        if migration_progress != 0:
-            return
-
-        self.migrating_state = False
-        await self.networking.send_message(
-            DISCOVERY_HOST,
-            DISCOVERY_PORT + 1,
-            msg=b"",
-            msg_type=MessageType.MigrationDone,
-            serializer=Serializer.NONE,
-        )
-        logging.warning(
-            f"MIGRATION_FINISHED at epoch: {self.sequencer.epoch_counter} at time: {time.time_ns() // 1_000_000}",
-        )
 
     async def _sync_cleanup(
         self,
@@ -930,7 +971,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             msg_type=MessageType.AriaFallbackStart,
             message=(self.id,),
             serializer=Serializer.MSGPACK,
-            send_async_migration_message=True,
         )
         if fallback_tasks:
             await asyncio.gather(*fallback_tasks)
@@ -943,7 +983,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             msg_type=MessageType.AriaFallbackDone,
             message=(self.id,),
             serializer=Serializer.MSGPACK,
-            send_async_migration_message=True,
         )
 
     async def unlock_tid(self, t_id_to_unlock: int) -> None:
@@ -1005,7 +1044,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         msg_type: MessageType,
         message: tuple | bytes,
         serializer: Serializer = Serializer.MSGPACK,
-        send_async_migration_message: bool = False,
     ) -> None:
         await self.networking.send_message(
             DISCOVERY_HOST,
@@ -1014,7 +1052,5 @@ class AriaProtocol(BaseTransactionalProtocol):
             msg_type=msg_type,
             serializer=serializer,
         )
-        if send_async_migration_message:
-            await self.send_async_migrate_batch()
         await self.sync_workers_event[msg_type].wait()
         self.sync_workers_event[msg_type].clear()

--- a/worker/worker_service.py
+++ b/worker/worker_service.py
@@ -552,26 +552,6 @@ class Worker:
             restart_after_migration=True,
         )
 
-    async def _migration_sync_and_resume(self) -> None:
-        logging.warning("MIGRATION | SENDING MigrationInitDone TO COORDINATOR")
-        await self.networking.send_message(
-            DISCOVERY_HOST,
-            DISCOVERY_PORT,
-            msg=b"",
-            msg_type=MessageType.MigrationInitDone,
-            serializer=Serializer.NONE,
-        )
-
-        logging.warning("MIGRATION | WAITING SYNC")
-        await self.migration_completed.wait()
-
-        # Start protocol after sync
-        self.function_execution_protocol.start()
-        self.function_execution_protocol.started.set()
-
-        # Reset sync events for next time
-        self.migration_completed.clear()
-
     async def _handle_receive_migration_hashes(
         self,
         data: bytes,

--- a/worker/worker_service.py
+++ b/worker/worker_service.py
@@ -13,7 +13,6 @@ import random
 import socket
 import struct
 import sys
-import threading
 import time
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any
@@ -142,7 +141,6 @@ class Worker:
 
         self.worker_operators: dict[OperatorPartition, Operator] | None = None
 
-        self.migration_repartitioning_done: asyncio.Event = asyncio.Event()
         self.migration_completed: asyncio.Event = asyncio.Event()
 
         self.m_input_offsets: dict[OperatorPartition, int] = {}
@@ -158,7 +156,9 @@ class Worker:
         self.deployed_graph: StateflowGraph | None = None
 
         self.final_keys_to_send = defaultdict(set)
-        self.results_lock = threading.Lock()
+        self._pending_hash_metadata: dict[OperatorPartition, dict[Any, tuple[int, int]]] = defaultdict(dict)
+        self._pending_migration_data: bytes | None = None
+        self.migration_error: BaseException | None = None
 
         self.networking_locks: dict[MessageType, asyncio.Lock] = {
             MessageType.ReceiveMigrationHashes: asyncio.Lock(),
@@ -193,28 +193,27 @@ class Worker:
         }
 
     @staticmethod
-    def rehash_and_store(
+    def rehash_only(
         operator_partition: OperatorPartition,
         partitioner: HashPartitioner,
         operator_partition_keys: list[Any],
-        dns: dict[str, dict[int, tuple[str, int, int]]],
         worker_id: int,
-    ) -> dict[OperatorPartition, set[tuple[Any, int]]]:
-        ser_time = 0.0
-        wire_time = 0.0
+    ) -> tuple[dict[OperatorPartition, set[tuple[Any, int]]], dict[OperatorPartition, dict[Any, tuple[int, int]]]]:
+        """Pure CPU rehashing — no network I/O.
+
+        Returns:
+            (keys_to_send, hash_metadata)
+            - keys_to_send: {(op_name, old_partition): {(key, new_partition), ...}}
+            - hash_metadata: {(op_name, new_partition): {key: (worker_id, old_partition), ...}}
+        """
         operator_name, previous_partition = operator_partition
-        # Start hashing
         start_hashing = timer()
-        keys_to_send = defaultdict(set)
-        new_partitions: dict[OperatorPartition, dict[Any, tuple[int, int]]] = {
-            (operator_name, partition): {} for partition in range(partitioner.partitions)
-        }
+        keys_to_send: dict[OperatorPartition, set[tuple[Any, int]]] = defaultdict(set)
+        hash_metadata: dict[OperatorPartition, dict[Any, tuple[int, int]]] = defaultdict(dict)
         for key in operator_partition_keys:
             new_partition: int = partitioner.get_partition_no_cache(key)
-            operator_partition = (operator_name, new_partition)
             if new_partition != previous_partition:
-                # If this key is already in the correct partition no need to transfer it
-                new_partitions[operator_partition][key] = (
+                hash_metadata[(operator_name, new_partition)][key] = (
                     worker_id,
                     previous_partition,
                 )
@@ -222,59 +221,31 @@ class Worker:
                     (key, new_partition),
                 )
         end_hashing = timer()
-
-        def upload_partition(msg: bytes, worker_info: tuple[str, int, int]) -> float:
-            s_wire = timer()
-            try:
-                s = socket.socket()
-                s.connect((worker_info[0], worker_info[1]))
-                s.send(msg)
-                s.close()
-            except Exception:
-                sync_logging.exception("MIGRATION | NETWORK THREAD ERROR")
-            e_wire = timer()
-            return e_wire - s_wire
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            futures = []
-            for n_op, data in new_partitions.items():
-                if not data:
-                    continue  # Skip empty partitions
-                n_o, n_p = n_op
-                s_ser = timer()
-                serialized_hashes: bytes = NetworkingManager.encode_message(
-                    msg=(n_op, data),
-                    msg_type=MessageType.ReceiveMigrationHashes,
-                    serializer=Serializer.MSGPACK,
-                )
-                e_ser = timer()
-                ser_time += e_ser - s_ser
-                futures.append(
-                    executor.submit(upload_partition, serialized_hashes, dns[n_o][n_p]),
-                )
-
-            for fut in futures:
-                wire_time += fut.result()
-
         sync_logging.warning(
-            "MIGRATION of %s:%s | hashing_time: %.3fs | ser_time: %.3fs | wire_time: %.3fs",
+            "MIGRATION of %s:%s | hashing_time: %.3fs",
             operator_name,
             previous_partition,
             end_hashing - start_hashing,
-            ser_time,
-            wire_time,
         )
-        return keys_to_send
+        return keys_to_send, hash_metadata
 
     def repartitioning_callback(self, future: Future) -> None:
-        with self.results_lock:
-            self.completed_repartitioning += 1
-            keys_to_send = future.result()
-            for op_partition, keys in keys_to_send.items():
-                self.final_keys_to_send[op_partition].update(keys)
-            if self.completed_repartitioning == self.total_repartitioning:
-                self.completed_repartitioning_event.set()
-                self.completed_repartitioning = 0
+        # This callback runs on the event loop thread (scheduled via call_soon
+        # by asyncio.Future.add_done_callback), so no threading lock is needed.
+        self.completed_repartitioning += 1
+        try:
+            keys_to_send, hash_metadata = future.result()
+        except Exception:
+            logging.exception("MIGRATION | Repartitioning subprocess failed")
+            self.migration_error = future.exception()
+            self.completed_repartitioning_event.set()
+            return
+        for op_partition, keys in keys_to_send.items():
+            self.final_keys_to_send[op_partition].update(keys)
+        for dest_partition, key_map in hash_metadata.items():
+            self._pending_hash_metadata[dest_partition].update(key_map)
+        if self.completed_repartitioning == self.total_repartitioning:
+            self.completed_repartitioning_event.set()
 
     async def worker_controller(self, data: bytes) -> None:
         msg_type = self.networking.get_msg_type(data)
@@ -385,49 +356,29 @@ class Worker:
         logging.warning("Graph code updates not implemented yet! %s", data)
 
     async def _handle_init_migration(self, data: bytes, _: MessageType) -> None:
+        """Phase A: rehash in background while protocol keeps running."""
         try:
-            logging.warning(f"MIGRATION | START at {time.time_ns() // 1_000_000}")
-            start_time = timer()
-
-            t_stop_start = timer()
-            await self._migration_stop_protocol()
-            t_stop_end = timer()
-            logging.warning(
-                "MIGRATION | Function Execution Protocol Stopped! |"
-                f" @Epoch {self.function_execution_protocol.sequencer.epoch_counter} |"
-                f" took: {t_stop_end - t_stop_start}",
-            )
-
-            await self._migration_decode_and_apply_plan(data)
+            logging.warning(f"MIGRATION | PHASE A START at {time.time_ns() // 1_000_000}")
+            self._pending_migration_data = data
 
             t_repart_start = timer()
-            await self._migration_local_repartition()
-            await self._migration_coordinate_repartition_done()
+            await self._migration_background_repartition()
             t_repart_end = timer()
             logging.warning(
-                f"MIGRATION | REPARTITIONING DONE | took: {t_repart_end - t_repart_start}",
+                f"MIGRATION | PHASE A REHASHING DONE | took: {t_repart_end - t_repart_start}",
             )
 
-            t_deploy_start = timer()
-            await self._migration_rebuild_runtime()
-            t_deploy_end = timer()
-            logging.warning(
-                f"MIGRATION | LOADING DATA DONE | took: {t_deploy_end - t_deploy_start}",
+            # Signal coordinator that rehashing is done (no counters — those come in Phase B)
+            await self.networking.send_message(
+                DISCOVERY_HOST,
+                DISCOVERY_PORT,
+                msg=b"",
+                msg_type=MessageType.MigrationRepartitioningDone,
+                serializer=Serializer.NONE,
             )
-
-            t_sync_start = timer()
-            await self._migration_sync_and_resume()
-            t_sync_end = timer()
-            logging.warning(
-                f"MIGRATION | PROCESSING CONTINUES | took: {t_sync_end - t_sync_start}",
-            )
-
-            end_time = timer()
-            logging.warning(
-                f"Worker: {self.id} | Migration took: {round((end_time - start_time) * 1000, 4)}ms",
-            )
+            logging.warning("MIGRATION | PHASE A COMPLETE — waiting for coordinator to stop protocol")
         except Exception as e:
-            logging.error(f"Uncaught exception while migrating: {e}")
+            logging.error(f"Uncaught exception during migration Phase A: {e}")
 
     async def _migration_stop_protocol(self) -> None:
         await self.function_execution_protocol.wait_stopped()
@@ -446,54 +397,119 @@ class Worker:
         self.worker_operators = new_worker_operators
         await asyncio.sleep(0)
 
-    async def _migration_local_repartition(self) -> None:
+    async def _migration_background_repartition(self) -> None:
+        """Phase A repartitioning: rehash keys in subprocesses (no network I/O).
+
+        Decodes the pending plan to get the new graph, but does NOT apply
+        the plan (dns, peers, worker_operators) — that happens in Phase B.
+        """
+        # Reset state from any previous migration
+        self.final_keys_to_send.clear()
+        self._pending_hash_metadata.clear()
+        self.completed_repartitioning = 0
+        self.completed_repartitioning_event.clear()
+        self.migration_error = None
+
+        # Decode the plan to get the new graph (for partitioners) without applying it
+        (
+            pending_graph,
+            _new_worker_operators,
+            _dns,
+            _peers,
+            _operator_state_backend,
+        ) = self.networking.decode_message(self._pending_migration_data)
+
         operator_partitions_to_repartition = self.local_state.get_operator_partitions_to_repartition()
         self.total_repartitioning = sum(len(parts) for parts in operator_partitions_to_repartition.values())
+
+        if self.total_repartitioning == 0:
+            self.completed_repartitioning_event.set()
+            return
 
         loop = asyncio.get_running_loop()
         for (
             operator_name,
             operator_partitions,
         ) in operator_partitions_to_repartition.items():
-            new_partitioner: HashPartitioner = self.deployed_graph.get_operator_by_name(
+            new_partitioner: HashPartitioner = pending_graph.get_operator_by_name(
                 operator_name,
             ).get_partitioner()
             for operator_partition in operator_partitions:
                 logging.warning(f"Sending: {operator_partition} for repartitioning")
+                # Offload key list copy to a thread (Step 8)
+                key_list = await loop.run_in_executor(
+                    None,
+                    lambda op=operator_partition: list(
+                        self.local_state.get_operator_data_for_repartitioning(op).keys(),
+                    ),
+                )
                 loop.run_in_executor(
                     self.pool,
-                    self.rehash_and_store,
+                    self.rehash_only,
                     operator_partition,
                     new_partitioner,
-                    list(
-                        self.local_state.get_operator_data_for_repartitioning(
-                            operator_partition,
-                        ).keys(),
-                    ),
-                    self.dns,
+                    key_list,
                     self.id,
                 ).add_done_callback(self.repartitioning_callback)
 
-        self.completed_repartitioning_event.clear()
         await self.completed_repartitioning_event.wait()
-        logging.warning("Local Repartitioning completed")
 
-        self.local_state.add_keys_to_send(self.final_keys_to_send)
+        if self.migration_error is not None:
+            raise self.migration_error
 
-    async def _migration_coordinate_repartition_done(self) -> None:
-        await self.networking.send_message(
-            DISCOVERY_HOST,
-            DISCOVERY_PORT,
-            msg=(
-                self.function_execution_protocol.sequencer.epoch_counter,
-                self.function_execution_protocol.sequencer.t_counter,
-                self.function_execution_protocol.topic_partition_offsets,
-                self.function_execution_protocol.egress.topic_partition_output_offsets,
-            ),
-            msg_type=MessageType.MigrationRepartitioningDone,
-            serializer=Serializer.MSGPACK,
-        )
-        await self.migration_repartitioning_done.wait()
+        logging.warning("Background repartitioning completed")
+
+    async def _migration_catchup_rehash(self) -> None:
+        """Catch-up pass: rehash keys created during Phase A that weren't in the original snapshot."""
+        operator_partitions_to_repartition = self.local_state.get_operator_partitions_to_repartition()
+        for operator_name, operator_partitions in operator_partitions_to_repartition.items():
+            new_partitioner: HashPartitioner = self.deployed_graph.get_operator_by_name(
+                operator_name,
+            ).get_partitioner()
+            for operator_partition in operator_partitions:
+                current_keys = set(
+                    self.local_state.get_operator_data_for_repartitioning(operator_partition).keys(),
+                )
+                # Keys already in final_keys_to_send for this partition
+                already_rehashed = {k for k, _ in self.final_keys_to_send.get(operator_partition, set())}
+                new_keys = current_keys - already_rehashed
+                if not new_keys:
+                    continue
+                _, previous_partition = operator_partition
+                for key in new_keys:
+                    new_partition: int = new_partitioner.get_partition_no_cache(key)
+                    if new_partition != previous_partition:
+                        self._pending_hash_metadata[(operator_name, new_partition)][key] = (
+                            self.id,
+                            previous_partition,
+                        )
+                        self.final_keys_to_send[operator_partition].add(
+                            (key, new_partition),
+                        )
+                logging.warning(
+                    f"MIGRATION | Catch-up rehashed {len(new_keys)} keys for {operator_partition}",
+                )
+
+    async def _migration_send_hash_metadata(self) -> None:
+        """Send hash metadata to destination workers via NetworkingManager in parallel."""
+        send_tasks = []
+        for dest_partition, key_map in self._pending_hash_metadata.items():
+            if not key_map:
+                continue
+            operator_name, partition = dest_partition
+            worker_info = self.dns[operator_name][partition]
+            send_tasks.append(
+                self.networking.send_message(
+                    worker_info[0],
+                    worker_info[1],
+                    msg=(dest_partition, key_map),
+                    msg_type=MessageType.ReceiveMigrationHashes,
+                    serializer=Serializer.MSGPACK,
+                ),
+            )
+        if send_tasks:
+            await asyncio.gather(*send_tasks)
+        self._pending_hash_metadata.clear()
 
     async def _migration_rebuild_runtime(self) -> None:
         await self._reset_protocol_networking()
@@ -555,7 +571,6 @@ class Worker:
 
         # Reset sync events for next time
         self.migration_completed.clear()
-        self.migration_repartitioning_done.clear()
 
     async def _handle_receive_migration_hashes(
         self,
@@ -594,24 +609,105 @@ class Worker:
         operator_partition, key, value = self.networking.decode_message(data)
         async with self.networking_locks[msg_type]:
             self.local_state.set_data_from_migration(operator_partition, key, value)
-            self.protocol_networking.key_received(operator_partition, key)
+            # Guard: the event may have been already signaled by the async
+            # migration handler, or may not exist if no transaction requested it.
+            op = tuple(operator_partition)
+            if (
+                op in self.protocol_networking.wait_remote_key_event
+                and key in self.protocol_networking.wait_remote_key_event[op]
+            ):
+                self.protocol_networking.key_received(op, key)
 
     async def _handle_migration_repartitioning_done(
         self,
-        data: bytes,
+        _data: bytes,
         _: MessageType,
     ) -> None:
-        logging.warning("MIGRATION | REPARTITIONING DONE FROM COORDINATOR")
+        """Phase B: protocol stops, catch-up, send hashes, rebuild, resume."""
+        try:
+            logging.warning(f"MIGRATION | PHASE B START at {time.time_ns() // 1_000_000}")
+            phase_b_start = timer()
+
+            # 1. Stop the protocol (coordinator already set stop_in_next_epoch)
+            t_stop_start = timer()
+            await self._migration_stop_protocol()
+            t_stop_end = timer()
+            logging.warning(
+                "MIGRATION | PHASE B Protocol Stopped |"
+                f" @Epoch {self.function_execution_protocol.sequencer.epoch_counter} |"
+                f" took: {t_stop_end - t_stop_start}",
+            )
+
+            # 2. Decode and apply the plan (dns, peers, worker_operators)
+            await self._migration_decode_and_apply_plan(self._pending_migration_data)
+            self._pending_migration_data = None
+
+            # 3. Catch-up pass: find keys created during Phase A that weren't rehashed
+            t_catchup_start = timer()
+            await self._migration_catchup_rehash()
+            t_catchup_end = timer()
+            logging.warning(
+                f"MIGRATION | PHASE B Catch-up rehash | took: {t_catchup_end - t_catchup_start}",
+            )
+
+            # 4. Register keys_to_send in local_state
+            self.local_state.add_keys_to_send(self.final_keys_to_send)
+
+            # 5. Send hash metadata to destination workers via NetworkingManager (parallel)
+            t_hash_send_start = timer()
+            await self._migration_send_hash_metadata()
+            t_hash_send_end = timer()
+            logging.warning(
+                f"MIGRATION | PHASE B Hash metadata sent | took: {t_hash_send_end - t_hash_send_start}",
+            )
+
+            # 6. Send MigrationInitDone with actual stop-time counters
+            await self.networking.send_message(
+                DISCOVERY_HOST,
+                DISCOVERY_PORT,
+                msg=(
+                    self.function_execution_protocol.sequencer.epoch_counter,
+                    self.function_execution_protocol.sequencer.t_counter,
+                    self.function_execution_protocol.topic_partition_offsets,
+                    self.function_execution_protocol.egress.topic_partition_output_offsets,
+                ),
+                msg_type=MessageType.MigrationInitDone,
+                serializer=Serializer.MSGPACK,
+            )
+
+            # 7. Wait for MigrationDone (carries merged counters from coordinator)
+            logging.warning("MIGRATION | PHASE B WAITING FOR MigrationDone")
+            await self.migration_completed.wait()
+
+            # 8. Rebuild runtime (now has correct merged counters from MigrationDone)
+            t_deploy_start = timer()
+            await self._migration_rebuild_runtime()
+            t_deploy_end = timer()
+            logging.warning(
+                f"MIGRATION | PHASE B Runtime rebuilt | took: {t_deploy_end - t_deploy_start}",
+            )
+
+            # 9. Start protocol with background migration
+            self.function_execution_protocol.start()
+            self.function_execution_protocol.started.set()
+
+            # Reset sync events for next time
+            self.migration_completed.clear()
+
+            phase_b_end = timer()
+            logging.warning(
+                f"Worker: {self.id} | PHASE B took: {round((phase_b_end - phase_b_start) * 1000, 4)}ms",
+            )
+        except Exception as e:
+            logging.error(f"Uncaught exception during migration Phase B: {e}")
+
+    async def _handle_migration_done(self, data: bytes, _: MessageType) -> None:
         (
             self.m_epoch_counter,
             self.m_t_counter,
             self.m_input_offsets,
             self.m_output_offsets,
         ) = self.networking.decode_message(data)
-        self.migration_repartitioning_done.set()
-        await asyncio.sleep(0)
-
-    async def _handle_migration_done(self, _data: bytes, _: MessageType) -> None:
         self.migration_completed.set()
         await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary

Restructures state migration into a two-phase design that minimizes the stop-the-world window from seconds to ~50-300ms:

- **Phase A** (protocol keeps running): Rehash keys in `ProcessPoolExecutor` subprocesses — pure CPU, no network I/O. `rehash_and_store` → `rehash_only` removes the per-subprocess `ThreadPoolExecutor` and direct TCP sends.
- **Phase B** (brief protocol stop): Catch-up rehash for keys created during Phase A, send hash metadata via `NetworkingManager` in parallel, rebuild runtime with merged counters, resume.
- **Phase C** (protocol running): `_continuous_migration_sender` background coroutine sends data batches independently of epoch barriers with parallel `asyncio.gather` sends.

### Key changes

- **Deferred `stop_in_next_epoch`**: Protocol only stops after all workers finish background rehashing (coordinator acquires `SyncCleanup` lock to prevent race with epoch cleanup)
- **Counter exchange moved**: `MigrationRepartitioningDone` → barrier-only; `MigrationInitDone` → carries epoch/t_counter/offsets; `MigrationDone` → carries merged counters from coordinator
- **Decoupled async migration from epoch barriers**: Removed `send_async_migration_message` parameter from `sync_workers()` and `_maybe_finish_async_migration()` from epoch loop
- **Catch-up rehash**: Phase B computes `current_keys - already_rehashed` to find keys created during Phase A
- **Race condition fixes**:
  - `get_key_to_migrate`: Use `pop(key, None)` + guard for key already transferred by async batch
  - `set_data_from_migration`: Only clean up `remote_keys` when `data is not None` (async batch may arrive later)
  - `set_batch_data_from_migration`: Guard `remote_keys` existence before deletion
  - `get_async_migrate_batch`: Skip `None` values (key deleted between rehash and transfer)
  - `exists()`: Fixed logic — key in `data` but queued in `keys_to_send` should return `False`; key in `data` without migration context should return `True`
- **Kafka ingress local redirect fix**: Preserve `kafka_offset` and use `msg.partition` (not client-specified `partition`) in `kafka_ingress_partition` to prevent duplicate egress messages after migration