### PR TITLE
Remove fallback cache; fix fallback deadlock, duplicate egress, and Aria hot paths

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Ruff
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "ruff==0.15.6"
+          python -m pip install "ruff==0.15.12"
 
       - name: Ruff lint (must pass)
         run: ruff check .

--- a/coordinator/coordinator.dockerfile
+++ b/coordinator/coordinator.dockerfile
@@ -32,10 +32,8 @@ EXPOSE 8888
 
 ARG enable_compression=true
 ARG use_composite_keys=true
-ARG use_fallback_cache=true
 
 ENV ENABLE_COMPRESSION=$enable_compression \
-    USE_COMPOSITE_KEYS=$use_composite_keys \
-    USE_FALLBACK_CACHE=$use_fallback_cache
+    USE_COMPOSITE_KEYS=$use_composite_keys
 
 CMD ["/usr/local/bin/start-coordinator.sh"]

--- a/coordinator/coordinator.dockerfile
+++ b/coordinator/coordinator.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.3-slim-trixie
+FROM python:3.14.5-slim-trixie
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/coordinator/coordinator_service.py
+++ b/coordinator/coordinator_service.py
@@ -711,7 +711,14 @@ class CoordinatorService:
                         data = await reader.readexactly(8)
                         (size,) = struct.unpack(">Q", data)
                         message = await reader.readexactly(size)
-                        self.aio_task_scheduler_coord.create_task(
+                        # Unbounded: this scheduler also runs
+                        # `heartbeat_monitor_coroutine` (a perpetual loop) which
+                        # drives recovery via `wait_cluster_healthy()` — that
+                        # await is unblocked by `_handle_ready_after_recovery`
+                        # running through this same scheduler. A bounded slot
+                        # held by a suspended awaiter could starve the setter
+                        # under a large cluster.
+                        self.aio_task_scheduler_coord.create_unbounded_task(
                             self.coordinator_controller(writer, message, pool),
                         )
                 except asyncio.IncompleteReadError as e:
@@ -976,7 +983,11 @@ class CoordinatorService:
         logging.warning("Coordinator Booted Successfully")
         self.init_snapshot_bucket()
         logging.warning("Coordinator Connected to S3")
-        self.aio_task_scheduler_coord.create_task(self.heartbeat_monitor_coroutine())
+        # Unbounded: heartbeat_monitor is a long-lived loop that also drives
+        # recovery (awaits `wait_cluster_healthy`). It must not consume a
+        # semaphore slot while suspended, or it would permanently reduce the
+        # scheduler's capacity and could starve `_handle_ready_after_recovery`.
+        self.aio_task_scheduler_coord.create_unbounded_task(self.heartbeat_monitor_coroutine())
         logging.warning("Coordinator Heartbeat Sentinel online")
         self.snapshotting_task = asyncio.create_task(self.send_snapshot_marker())
         logging.warning("Coordinator Snapshotting online")

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -1,15 +1,15 @@
 setuptools==82.0.1
 # networking service
 uvloop==0.22.1
-msgspec==0.20.0
+msgspec==0.21.1
 cloudpickle==3.1.2
 cityhash==0.4.10
 zstandard==0.25.0
 # monitoring service
-prometheus-client==0.24.1
+prometheus-client==0.25.0
 # kafka
-confluent-kafka==2.13.2
+confluent-kafka==2.14.0
 # snapshots
-boto3==1.42.68
+boto3==1.43.7
 # deathstar
 geopy

--- a/demo/demo-migration-tpc-c/pure_kafka_demo.py
+++ b/demo/demo-migration-tpc-c/pure_kafka_demo.py
@@ -64,10 +64,8 @@ MIN_PAYMENT = 1.0
 MAX_PAYMENT = 5000.0
 enable_compression: bool = bool(strtobool(sys.argv[9]))
 use_composite_keys: bool = bool(strtobool(sys.argv[10]))
-use_fallback_cache: bool = bool(strtobool(sys.argv[11]))
 os.environ["ENABLE_COMPRESSION"] = str(enable_compression)
 os.environ["USE_COMPOSITE_KEYS"] = str(use_composite_keys)
-os.environ["USE_FALLBACK_CACHE"] = str(use_fallback_cache)
 
 
 customers_per_district: dict[tuple, list] = {}

--- a/demo/demo-tpc-c/calculate_metrics.py
+++ b/demo/demo-tpc-c/calculate_metrics.py
@@ -13,19 +13,16 @@ def main(
         client_threads,
         n_w,
         enable_compression,
-        use_composite_keys,
-        use_fallback_cache):
+        use_composite_keys):
 
     ablation_configs = {
-        (True, True, True): "ALL",
-        (False, True, True): "NO_COMP",
-        (True, False, True): "NO_CK",
-        (True, True, False): "NO_FC",
+        (True, True): "ALL",
+        (False, True): "NO_COMP",
+        (True, False): "NO_CK",
     }
 
     exp_name = f"tpcc_W{n_w}_{input_rate * client_threads}_{ablation_configs[(enable_compression,
-                                                                              use_composite_keys,
-                                                                              use_fallback_cache)]}"
+                                                                              use_composite_keys)]}"
 
     origin_input_msgs = pd.read_csv(f"{save_dir}/client_requests.csv",
                                     dtype={"request_id": bytes,

--- a/demo/demo-tpc-c/pure_kafka_demo.py
+++ b/demo/demo-tpc-c/pure_kafka_demo.py
@@ -65,11 +65,9 @@ MIN_PAYMENT = 1.0
 MAX_PAYMENT = 5000.0
 enable_compression: bool = bool(strtobool(sys.argv[8]))
 use_composite_keys: bool = bool(strtobool(sys.argv[9]))
-use_fallback_cache: bool = bool(strtobool(sys.argv[10]))
 os.environ["ENABLE_COMPRESSION"] = str(enable_compression)
 os.environ["USE_COMPOSITE_KEYS"] = str(use_composite_keys)
-os.environ["USE_FALLBACK_CACHE"] = str(use_fallback_cache)
-kill_at = int(sys.argv[11]) if len(sys.argv) > 11 else -1
+kill_at = int(sys.argv[10]) if len(sys.argv) > 10 else -1
 
 
 customers_per_district: dict[tuple, list] = {}
@@ -407,7 +405,7 @@ def tpc_c_workload_generator(proc_num):
 
 def benchmark_runner(proc_num) -> dict[bytes, dict]:
     print(f'Generator: {proc_num} starting with: EC={os.environ["ENABLE_COMPRESSION"]} '
-          f'CK={os.environ["USE_COMPOSITE_KEYS"]} FC={os.environ["USE_FALLBACK_CACHE"]}')
+          f'CK={os.environ["USE_COMPOSITE_KEYS"]}')
     styx = SyncStyxClient(STYX_HOST, STYX_PORT, kafka_url=KAFKA_URL)
     styx.open(consume=False)
     tpc_c_generator = tpc_c_workload_generator(proc_num)
@@ -485,5 +483,4 @@ if __name__ == "__main__":
         N_W,
         enable_compression,
         use_composite_keys,
-        use_fallback_cache
     )

--- a/docs/styx-docs/docker-env-variables.md
+++ b/docs/styx-docs/docker-env-variables.md
@@ -106,7 +106,6 @@ These environment variables configure the **Styx Worker**, including discovery, 
 |------------------------------|----------------|----------------------------------------------------------------------------|
 | `CONFLICT_DETECTION_METHOD` | `0`            | Styx's conflict detection strategy                                         |
 | `FALLBACK_STRATEGY_PERCENTAGE` | `-0.1`       | % aborts before fallback logic triggers (negative enables it at all times) |
-| `USE_FALLBACK_CACHE`         | `True`         | Whether to use the fallback cache mechanism                                |
 
 ---
 

--- a/docs/styx-docs/running-experiments.md
+++ b/docs/styx-docs/running-experiments.md
@@ -105,7 +105,7 @@ sudo kubefwd --version
   <workload_name> <input_rate> <n_keys> <n_part> <zipf_const> \
   <client_threads> <total_time> <saving_dir> <warmup_seconds> <epoch_size> \
   [styx_threads_per_worker] [enable_compression] [use_composite_keys] \
-  [use_fallback_cache] [regenerate_tpcc_data]
+  [regenerate_tpcc_data]
 ```
 
 ### Parameters
@@ -125,8 +125,7 @@ sudo kubefwd --version
 | 11 _(optional)_ | `styx_threads_per_worker` | Worker threads per container (default: `1`) |
 | 12 _(optional)_ | `enable_compression` | `true`/`false` — ZSTD snapshot compression (default: `true`) |
 | 13 _(optional)_ | `use_composite_keys` | `true`/`false` — composite key hashing (default: `true`) |
-| 14 _(optional)_ | `use_fallback_cache` | `true`/`false` — fallback result cache (default: `true`) |
-| 15 _(optional)_ | `regenerate_tpcc_data` | `true`/`false` — force TPC-C data regeneration (default: `false`) |
+| 14 _(optional)_ | `regenerate_tpcc_data` | `true`/`false` — force TPC-C data regeneration (default: `false`) |
 
 ### Environment variables
 
@@ -220,7 +219,7 @@ Runs a benchmark in which the number of partitions is scaled (up or down) mid-ex
   <total_time> <saving_dir> <warmup_seconds> <epoch_size> \
   <workload_name> <n_keys> \
   [regenerate_tpcc_data] [styx_threads_per_worker] \
-  [enable_compression] [use_composite_keys] [use_fallback_cache]
+  [enable_compression] [use_composite_keys]
 ```
 
 ### Workloads

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,35 +3,35 @@ Cython==3.2.4
 # STYX
 # networking service
 uvloop==0.22.1
-msgspec==0.20.0
+msgspec==0.21.1
 cloudpickle==3.1.2
 cityhash==0.4.10
 zstandard==0.25.0
 # monitoring service
-prometheus-client==0.24.1
+prometheus-client==0.25.0
 psutil==7.2.2
 # Kafka
-aiokafka==0.13.0
-confluent-kafka==2.13.2
+aiokafka==0.14.0
+confluent-kafka==2.14.0
 # snapshots
-boto3==1.42.68
+boto3==1.43.7
 # deathstar
 geopy
 # shopping cart demo
 sanic==25.12.0
-aiohttp==3.13.3
-locust==2.43.3
+aiohttp==3.13.5
+locust==2.44.0
 # Plots and demo
-pandas==3.0.1
+pandas==3.0.3
 tqdm==4.67.3
-numpy==2.4.3
+numpy==2.4.4
 scipy==1.17.1
-matplotlib==3.10.8
+matplotlib==3.10.9
 # docs
-mkdocs-material==9.7.5
+mkdocs-material==9.7.6
 # tests
-pytest==9.0.2
+pytest==9.0.3
 pytest-asyncio==1.3.0
-testcontainers[kafka,minio]>=4.14.1
+testcontainers[kafka,minio]>=4.14.2
 # make sure to have the same ruff verseion as in .github/workflows/ruff.yml line 30
-ruff==0.15.6
+ruff==0.15.12

--- a/scripts/create_config.py
+++ b/scripts/create_config.py
@@ -223,13 +223,12 @@ input_throughput = [
 ]
 
 
-# define the four configurations
+# define the three configurations
 configs = [
-    # (enable_compression, use_composite_keys, use_fallback_cache, suffix)
-    (True,  True,  True,  "ALL"),
-    (False, True,  True,  "NO_COMP"),
-    (True,  False, True,  "NO_CK"),
-    (True,  True,  False, "NO_FC"),
+    # (enable_compression, use_composite_keys, suffix)
+    (True,  True,  "ALL"),
+    (False, True,  "NO_COMP"),
+    (True,  False, "NO_CK"),
 ]
 
 if "tpcc" in scenarios:
@@ -238,7 +237,7 @@ if "tpcc" in scenarios:
             # skip rates above the per-worker cap
             if input_rate > max_rate[n_w]:
                 continue
-            for enable_compression, use_composite_keys, use_fallback_cache, tag in configs:
+            for enable_compression, use_composite_keys, tag in configs:
                 # file name now encodes the variant tag
                 file_name = f"tpcc_W{n_w}_{input_rate * n_threads}_{tag}.json"
 
@@ -255,7 +254,6 @@ if "tpcc" in scenarios:
                         100,
                         enable_compression,
                         use_composite_keys,
-                        use_fallback_cache
                     ))
 
 df = pd.DataFrame(lines)

--- a/scripts/run_batch_experiments.sh
+++ b/scripts/run_batch_experiments.sh
@@ -58,10 +58,9 @@ do
   epoch_size="${ss[8]}"
   enable_compression="${ss[9]}"
   use_composite_keys="${ss[10]}"
-  use_fallback_cache="${ss[11]}"
 
   ./scripts/run_experiment.sh "$workload_name" "$input_rate" "$n_keys" "$n_part" "$zipf_const" "$client_threads" \
                               "$total_time" "$saving_dir" "$warmup_seconds" "$epoch_size" "$styx_threads_per_worker" \
-                              "$enable_compression" "$use_composite_keys" "$use_fallback_cache"
+                              "$enable_compression" "$use_composite_keys"
 
 done < "$input"

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -3,7 +3,6 @@
 styx_threads_per_worker=1
 enable_compression=true
 use_composite_keys=true
-use_fallback_cache=true
 regenerate_tpcc_data=false
 
 workload_name=$1
@@ -20,8 +19,7 @@ epoch_size=${10}
 [ -n "${11}" ] && styx_threads_per_worker=${11}
 [ -n "${12}" ] && enable_compression=${12}
 [ -n "${13}" ] && use_composite_keys=${13}
-[ -n "${14}" ] && use_fallback_cache=${14}
-[ -n "${15}" ] && regenerate_tpcc_data=${15}
+[ -n "${14}" ] && regenerate_tpcc_data=${14}
 kill_at="-1" # This means that we are not going to kill any containers using this script
 
 # Deployment mode configuration (read from environment).
@@ -44,7 +42,6 @@ echo "epoch_size: $epoch_size"
 echo "styx_threads_per_worker: $styx_threads_per_worker"
 echo "enable_compression: $enable_compression"
 echo "use_composite_keys: $use_composite_keys"
-echo "use_fallback_cache: $use_fallback_cache"
 echo "regenerate_tpcc_data: $regenerate_tpcc_data"
 echo "deploy_mode: $DEPLOY_MODE"
 echo "==================================================="
@@ -78,7 +75,7 @@ if [[ "$DEPLOY_MODE" == "k8s-minikube" || "$DEPLOY_MODE" == "k8s-cluster" ]]; th
 
 else
     # docker-compose mode
-    bash scripts/start_styx_cluster.sh "$n_part" "$epoch_size" "$styx_threads_per_worker" "$enable_compression" "$use_composite_keys" "$use_fallback_cache"
+    bash scripts/start_styx_cluster.sh "$n_part" "$epoch_size" "$styx_threads_per_worker" "$enable_compression" "$use_composite_keys"
     sleep 10
 fi
 
@@ -123,7 +120,7 @@ elif [[ $workload_name == "tpcc" ]]; then
     python demo/demo-tpc-c/pure_kafka_demo.py \
         "$saving_dir" "$client_threads" "$n_part" \
         "$input_rate" "$total_time" "$warmup_seconds" \
-        "$n_keys" "$enable_compression" "$use_composite_keys" "$use_fallback_cache" "$kill_at"
+        "$n_keys" "$enable_compression" "$use_composite_keys" "$kill_at"
 else
     echo "Benchmark not supported!"
 fi

--- a/scripts/run_migration_experiment.sh
+++ b/scripts/run_migration_experiment.sh
@@ -8,7 +8,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 styx_threads_per_worker=1
 enable_compression=true
 use_composite_keys=true
-use_fallback_cache=true
 regenerate_tpcc_data=false
 
 # Read positional arguments
@@ -28,7 +27,6 @@ n_keys=${10}
 [ -n "${12:-}" ] && styx_threads_per_worker=${12}
 [ -n "${13:-}" ] && enable_compression=${13}
 [ -n "${14:-}" ] && use_composite_keys=${14}
-[ -n "${15:-}" ] && use_fallback_cache=${15}
 
 # Determine the maximum number of partitions
 if (( start_n_part > end_n_part )); then
@@ -52,13 +50,12 @@ echo "n_keys: $n_keys"
 echo "styx_threads_per_worker: $styx_threads_per_worker"
 echo "enable_compression: $enable_compression"
 echo "use_composite_keys: $use_composite_keys"
-echo "use_fallback_cache: $use_fallback_cache"
 echo "regenerate_tpcc_data: $regenerate_tpcc_data"
 echo "============================================================"
 
 bash "$ROOT_DIR/scripts/start_styx_cluster.sh" \
   "$start_n_part" "$epoch_size" "$styx_threads_per_worker" \
-  "$enable_compression" "$use_composite_keys" "$use_fallback_cache"
+  "$enable_compression" "$use_composite_keys"
 
 sleep 10
 
@@ -98,7 +95,7 @@ elif [[ "$workload_name" == "tpcc" ]]; then
     python "$ROOT_DIR/demo/demo-migration-tpc-c/pure_kafka_demo.py" \
         "$saving_dir" "$client_threads" "$start_n_part" "$end_n_part" \
         "$input_rate" "$total_time" "$warmup_seconds" "$n_keys" \
-        "$enable_compression" "$use_composite_keys" "$use_fallback_cache"
+        "$enable_compression" "$use_composite_keys"
 
 else
     echo "Benchmark not supported: $workload_name"

--- a/scripts/start_styx_cluster.sh
+++ b/scripts/start_styx_cluster.sh
@@ -5,7 +5,6 @@ epoch_size=$2
 threads_per_worker=$3
 enable_compression=$4
 use_composite_keys=$5
-use_fallback_cache=$6
 minimum_amount_of_workers=1
 
 echo "============== Starting Styx Cluster ================"
@@ -15,7 +14,6 @@ echo "threads_per_worker: $threads_per_worker"
 echo "minimum_amount_of_workers: $minimum_amount_of_workers"
 echo "enable_compression: $enable_compression"
 echo "use_composite_keys: $use_composite_keys"
-echo "use_fallback_cache: $use_fallback_cache"
 # Ceiling division
 threaded_scale_factor=$(( (scale_factor + threads_per_worker - 1) / threads_per_worker ))
 # Enforce minimum
@@ -34,7 +32,6 @@ docker compose build \
     --build-arg epoch_size="$epoch_size" \
     --build-arg worker_threads="$threads_per_worker" \
     --build-arg enable_compression="$enable_compression" \
-    --build-arg use_composite_keys="$use_composite_keys" \
-    --build-arg use_fallback_cache="$use_fallback_cache"
+    --build-arg use_composite_keys="$use_composite_keys"
 docker compose up --scale worker="$threaded_scale_factor" -d >/dev/null
 sleep 5

--- a/styx-package/pyproject.toml
+++ b/styx-package/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "msgspec>=0.20.0,<1.0.0",
     # Kafka clients (async/sync)
     "aiokafka>=0.12.0,<1.0",
-    "confluent-kafka>=2.13.0,<2.14",
+    "confluent-kafka>=2.14.0,<3.0.0",
     # Hashing
     "cityhash>=0.4.10,<1.0.0",
     # Compression

--- a/styx-package/styx/common/base_networking.py
+++ b/styx-package/styx/common/base_networking.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 import asyncio
 from collections import defaultdict
 from enum import IntEnum
-import fractions
 import os
 from pickle import UnpicklingError
 import socket
@@ -46,8 +45,11 @@ class BaseNetworking(ABC):
 
         # event_id: |ack_event|
         self.waited_ack_events: dict[int, asyncio.Event] = {}
-        # tid: |fraction|
-        self.ack_fraction: dict[int, fractions.Fraction] = {}
+        # tid: |float fraction accumulated by leaves of the chain|
+        # We use float (not fractions.Fraction) for speed; chain ACK shares
+        # are 1/N at each level, and sums of those across leaves converge
+        # close to 1.0. Compare with an ε tolerance instead of equality.
+        self.ack_fraction: dict[int, float] = {}
         # t_id: |list of workers|
         self.chain_participants: dict[int, list[int]] = defaultdict(list)
         self.aborted_events: dict[int, str] = {}
@@ -106,6 +108,12 @@ class BaseNetworking(ABC):
             if participant != self.worker_id and participant not in self.chain_participants[t_id]:
                 self.chain_participants[t_id].append(participant)
 
+    # Float ACK accounting: each chain leaf contributes share = 1/(N1*N2*...)
+    # where Ni is the fan-out at level i. Sum of all leaf shares should equal
+    # 1.0 modulo floating-point error. ε of 1e-9 tolerates accumulation error
+    # for chains with up to ~10^9 leaves — vastly more than any real workload.
+    _ACK_FRACTION_COMPLETE_EPSILON: float = 1e-9
+
     def add_ack_fraction_str(
         self,
         ack_id: int,
@@ -113,33 +121,25 @@ class BaseNetworking(ABC):
         chain_participants: list[int],
     ) -> None:
         if ack_id in self.aborted_events:
+            # if the transaction was aborted we can instantly return
             return
         try:
             self.add_chain_participants(ack_id, chain_participants)
-            self.ack_fraction[ack_id] += fractions.Fraction(fraction_str)
-            logging.warning(
-                f"ACK t_id={ack_id} += {fraction_str} -> {self.ack_fraction[ack_id]} "
-                f"participants={chain_participants}",
-            )
-            if self.ack_fraction[ack_id] == 1:
+            self.ack_fraction[ack_id] += float(fraction_str)
+            if self.ack_fraction[ack_id] >= 1.0 - self._ACK_FRACTION_COMPLETE_EPSILON:
                 self.waited_ack_events[ack_id].set()
-                logging.warning(f"ACK t_id={ack_id} complete (event set)")
-            elif self.ack_fraction[ack_id] > 1:
-                logging.error(
-                    f"ack: {ack_id} larger than 1 -> {self.ack_fraction[ack_id]}",
-                )
         except KeyError:
-            logging.error(f"TID: {ack_id} not in ack list! (event missing)")
+            logging.error(f"TID: {ack_id} not in ack list!")
 
     def prepare_function_chain(self, t_id: int) -> None:
-        logging.warning(f"PREPARE chain t_id={t_id}")
+        logging.info(f"New function chain for T_ID: {t_id}")
         self.waited_ack_events[t_id] = asyncio.Event()
-        self.ack_fraction[t_id] = fractions.Fraction(0)
+        self.ack_fraction[t_id] = 0.0
 
     def reset_ack_for_fallback(self, ack_id: int) -> None:
         if ack_id in self.waited_ack_events:
             self.waited_ack_events[ack_id].clear()
-            self.ack_fraction[ack_id] = fractions.Fraction(0)
+            self.ack_fraction[ack_id] = 0.0
 
     def clear_aborted_events_for_fallback(self) -> None:
         self.aborted_events.clear()

--- a/styx-package/styx/common/base_networking.py
+++ b/styx-package/styx/common/base_networking.py
@@ -113,22 +113,26 @@ class BaseNetworking(ABC):
         chain_participants: list[int],
     ) -> None:
         if ack_id in self.aborted_events:
-            # if the transaction was aborted we can instantly return
             return
         try:
             self.add_chain_participants(ack_id, chain_participants)
             self.ack_fraction[ack_id] += fractions.Fraction(fraction_str)
+            logging.warning(
+                f"ACK t_id={ack_id} += {fraction_str} -> {self.ack_fraction[ack_id]} "
+                f"participants={chain_participants}",
+            )
             if self.ack_fraction[ack_id] == 1:
                 self.waited_ack_events[ack_id].set()
+                logging.warning(f"ACK t_id={ack_id} complete (event set)")
             elif self.ack_fraction[ack_id] > 1:
                 logging.error(
                     f"ack: {ack_id} larger than 1 -> {self.ack_fraction[ack_id]}",
                 )
         except KeyError:
-            logging.error(f"TID: {ack_id} not in ack list!")
+            logging.error(f"TID: {ack_id} not in ack list! (event missing)")
 
     def prepare_function_chain(self, t_id: int) -> None:
-        logging.info(f"New function chain for T_ID: {t_id}")
+        logging.warning(f"PREPARE chain t_id={t_id}")
         self.waited_ack_events[t_id] = asyncio.Event()
         self.ack_fraction[t_id] = fractions.Fraction(0)
 

--- a/styx-package/styx/common/base_networking.py
+++ b/styx-package/styx/common/base_networking.py
@@ -7,7 +7,6 @@ import os
 from pickle import UnpicklingError
 import socket
 import struct
-from typing import TYPE_CHECKING
 
 from setuptools._distutils.util import strtobool
 
@@ -25,9 +24,6 @@ from styx.common.serialization import (
     zstd_msgpack_deserialization,
     zstd_msgpack_serialization,
 )
-
-if TYPE_CHECKING:
-    from styx.common.run_func_payload import RunFuncPayload
 
 USE_COMPRESSION: bool = bool(strtobool(os.getenv("ENABLE_COMPRESSION", "true")))
 COMPRESS_AFTER: int = int(os.getenv("COMPRESS_AFTER", "4096"))
@@ -52,14 +48,10 @@ class BaseNetworking(ABC):
         self.waited_ack_events: dict[int, asyncio.Event] = {}
         # tid: |fraction|
         self.ack_fraction: dict[int, fractions.Fraction] = {}
-        # tid: |count, total|
-        self.ack_cnts: dict[int, tuple[int, int]] = {}
         # t_id: |list of workers|
         self.chain_participants: dict[int, list[int]] = defaultdict(list)
         self.aborted_events: dict[int, str] = {}
         self.client_responses: dict[int, str] = {}
-        # t_id: functions that it runs
-        self.remote_function_calls: dict[int, list[RunFuncPayload]] = defaultdict(list)
         # set of t_ids that aborted because of an exception
         self.logic_aborts_everywhere: set[int] = set()
 
@@ -104,15 +96,10 @@ class BaseNetworking(ABC):
     def cleanup_after_epoch(self) -> None:
         self.waited_ack_events.clear()
         self.ack_fraction.clear()
-        self.ack_cnts.clear()
         self.aborted_events.clear()
-        self.remote_function_calls.clear()
         self.logic_aborts_everywhere.clear()
         self.chain_participants.clear()
         self.client_responses.clear()
-
-    def add_remote_function_call(self, t_id: int, payload: RunFuncPayload) -> None:
-        self.remote_function_calls[t_id].append(payload)
 
     def add_chain_participants(self, t_id: int, chain_participants: list[int]) -> None:
         for participant in chain_participants:
@@ -124,17 +111,12 @@ class BaseNetworking(ABC):
         ack_id: int,
         fraction_str: str,
         chain_participants: list[int],
-        partial_node_count: int,
     ) -> None:
         if ack_id in self.aborted_events:
             # if the transaction was aborted we can instantly return
             return
         try:
             self.add_chain_participants(ack_id, chain_participants)
-            self.ack_cnts[ack_id] = (
-                self.ack_cnts[ack_id][0],
-                self.ack_cnts[ack_id][1] + partial_node_count,
-            )
             self.ack_fraction[ack_id] += fractions.Fraction(fraction_str)
             if self.ack_fraction[ack_id] == 1:
                 self.waited_ack_events[ack_id].set()
@@ -145,39 +127,15 @@ class BaseNetworking(ABC):
         except KeyError:
             logging.error(f"TID: {ack_id} not in ack list!")
 
-    def add_ack_cnt(self, ack_id: int, cnt: int = 1) -> None:
-        if ack_id in self.aborted_events:
-            # if the transaction was aborted we can instantly return
-            return
-        try:
-            self.ack_cnts[ack_id] = (
-                self.ack_cnts[ack_id][0] + cnt,
-                self.ack_cnts[ack_id][1],
-            )
-            if self.ack_cnts[ack_id][0] == self.ack_cnts[ack_id][1]:
-                # All ACK parts have been gathered
-                self.waited_ack_events[ack_id].set()
-            elif self.ack_cnts[ack_id][0] > self.ack_cnts[ack_id][1]:
-                logging.error(
-                    f"ack: {ack_id} larger than total: {self.ack_cnts[ack_id][0]}>{self.ack_cnts[ack_id][1]}",
-                )
-        except KeyError:
-            logging.error(f"TID: {ack_id} not in ack list!")
-
     def prepare_function_chain(self, t_id: int) -> None:
         logging.info(f"New function chain for T_ID: {t_id}")
         self.waited_ack_events[t_id] = asyncio.Event()
         self.ack_fraction[t_id] = fractions.Fraction(0)
-        self.ack_cnts[t_id] = (0, 0)
 
     def reset_ack_for_fallback(self, ack_id: int) -> None:
         if ack_id in self.waited_ack_events:
             self.waited_ack_events[ack_id].clear()
             self.ack_fraction[ack_id] = fractions.Fraction(0)
-
-    def reset_ack_for_fallback_cache(self, ack_id: int) -> None:
-        if ack_id in self.waited_ack_events:
-            self.waited_ack_events[ack_id].clear()
 
     def clear_aborted_events_for_fallback(self) -> None:
         self.aborted_events.clear()

--- a/styx-package/styx/common/message_types.py
+++ b/styx-package/styx/common/message_types.py
@@ -27,7 +27,6 @@ class MessageType(IntEnum):
     SyncCleanup = 22
     RemoteWantsToProceed = 23
     ChainAbort = 24
-    AckCache = 25
     WrongPartitionRequest = 26
     InitMigration = 27
     MigrationRepartitioningDone = 28

--- a/styx-package/styx/common/operator.py
+++ b/styx-package/styx/common/operator.py
@@ -97,9 +97,8 @@ class Operator(BaseOperator):
         request_id: bytes,
         function_name: str,
         partition: int,
-        ack_payload: tuple[str, int, int, str, list[int], int] | None,
+        ack_payload: tuple[str, int, int, str, list[int]] | None,
         fallback_mode: bool,
-        use_fallback_cache: bool,
         params: tuple,
         protocol: BaseTransactionalProtocol,
     ) -> bool:
@@ -113,7 +112,6 @@ class Operator(BaseOperator):
             partition (int): Partition on which to execute the function.
             ack_payload (tuple | None): Metadata for acknowledgement in distributed chains.
             fallback_mode (bool): Whether to execute in fallback (recovery) mode.
-            use_fallback_cache (bool): Whether to use cached fallback results.
             params (tuple): Parameters to pass to the function.
             protocol (BaseTransactionalProtocol): Protocol for managing distributed transactional execution..
 
@@ -127,7 +125,6 @@ class Operator(BaseOperator):
             t_id,
             request_id,
             fallback_mode,
-            use_fallback_cache,
             protocol,
         )
         params = (f, *tuple(params))
@@ -140,38 +137,31 @@ class Operator(BaseOperator):
                 ack_id,
                 fraction_str,
                 chain_participants,
-                partial_node_count,
             ) = ack_payload
-            resp, n_remote_calls, partial_node_count = await f(
+            resp, n_remote_calls = await f(
                 *params,
                 ack_host=ack_host,
                 ack_port=ack_port,
                 ack_share=fraction_str,
                 chain_participants=chain_participants,
-                partial_node_count=partial_node_count,
             )
             if isinstance(resp, Exception):
                 await self._send_chain_abort(str(resp), ack_host, ack_port, ack_id)
                 success = False
-            elif fallback_mode and use_fallback_cache:
-                await self.__send_cache_ack(ack_host, ack_port, ack_id)
             elif n_remote_calls == 0:
-                # we need to count the last node as part of the chain
-                partial_node_count += 1
                 await self.__send_ack(
                     ack_host,
                     ack_port,
                     ack_id,
                     fraction_str,
                     chain_participants,
-                    partial_node_count,
                 )
             if success and resp is not None:
                 # send the response to the root
                 await self._send_response_to_root(resp, ack_host, ack_port, ack_id)
         else:
             # root of a chain, or single call
-            resp, _, _ = await f(*params)
+            resp, _ = await f(*params)
             if isinstance(resp, Exception):
                 self.__networking.abort_chain(t_id, str(resp))
                 success = False
@@ -224,27 +214,6 @@ class Operator(BaseOperator):
                 serializer=Serializer.MSGPACK,
             )
 
-    async def __send_cache_ack(self, ack_host: str, ack_port: int, ack_id: int) -> None:
-        """Sends an acknowledgement to the worker that holds the root of a distributed chain during fallback mode
-         with cache enabled.
-
-        Args:
-            ack_host: Hostname or IP of the next worker.
-            ack_port: Port number of the next worker.
-            ack_id: Acknowledgement ID for the cache.
-        """
-        if self.__networking.in_the_same_network(ack_host, ack_port):
-            # case when the ack host is the same worker
-            self.__networking.add_ack_cnt(ack_id)
-        else:
-            await self.__networking.send_message(
-                ack_host,
-                ack_port,
-                msg=(ack_id,),
-                msg_type=MessageType.AckCache,
-                serializer=Serializer.MSGPACK,
-            )
-
     async def __send_ack(
         self,
         ack_host: str,
@@ -252,7 +221,6 @@ class Operator(BaseOperator):
         ack_id: int,
         fraction_str: str,
         chain_participants: list[int],
-        partial_node_count: int,
     ) -> None:
         """Sends an acknowledgement to the worker that holds the root of a distributed chain during normal operation.
 
@@ -262,7 +230,6 @@ class Operator(BaseOperator):
             ack_id: Acknowledgement ID for the chain.
             fraction_str: Fraction of chain progress.
             chain_participants: List of worker IDs that participated in the chain.
-            partial_node_count: Count of nodes contributing to the result.
         """
         if self.__networking.in_the_same_network(ack_host, ack_port):
             # case when the ack host is the same worker
@@ -270,7 +237,6 @@ class Operator(BaseOperator):
                 ack_id,
                 fraction_str,
                 chain_participants,
-                partial_node_count,
             )
         else:
             if self.__networking.worker_id not in chain_participants:
@@ -278,7 +244,7 @@ class Operator(BaseOperator):
             await self.__networking.send_message(
                 ack_host,
                 ack_port,
-                msg=(ack_id, fraction_str, chain_participants, partial_node_count),
+                msg=(ack_id, fraction_str, chain_participants),
                 msg_type=MessageType.Ack,
                 serializer=Serializer.MSGPACK,
             )
@@ -291,7 +257,6 @@ class Operator(BaseOperator):
         t_id: int,
         request_id: bytes,
         fallback_mode: bool,
-        use_fallback_cache: bool,
         protocol: BaseTransactionalProtocol,
     ) -> StatefulFunction:
         """Constructs and binds a `StatefulFunction` instance.
@@ -303,7 +268,6 @@ class Operator(BaseOperator):
             t_id: Transaction ID.
             request_id: Unique request identifier.
             fallback_mode: Whether to use fallback logic.
-            use_fallback_cache: Whether to use the fallback cache.
             protocol: Coordination protocol to use.
 
         Returns:
@@ -323,7 +287,6 @@ class Operator(BaseOperator):
             t_id,
             request_id,
             fallback_mode,
-            use_fallback_cache,
             self.__deployed_graph,
             self.__run_func_lock,
             protocol,

--- a/styx-package/styx/common/run_func_payload.py
+++ b/styx-package/styx/common/run_func_payload.py
@@ -11,8 +11,8 @@ class RunFuncPayload:
     params: tuple
     kafka_offset: int = -1
     kafka_ingress_partition: int = -1
-    # host, port, t_id, stake, chain_participants, partial_node_count
-    ack_payload: tuple[str, int, int, str, list[int], int] | None = None
+    # host, port, t_id, stake, chain_participants
+    ack_payload: tuple[str, int, int, str, list[int]] | None = None
 
 
 @dataclass

--- a/styx-package/styx/common/stateful_function.py
+++ b/styx-package/styx/common/stateful_function.py
@@ -1,5 +1,4 @@
 import asyncio
-import fractions
 from typing import TYPE_CHECKING
 
 from styx.common.function import Function
@@ -257,7 +256,10 @@ class StatefulFunction(Function):
         n_remote_calls: int = len(self.__async_remote_calls)
         if n_remote_calls == 0:
             return n_remote_calls
-        new_share_fraction: str = str(fractions.Fraction(ack_share) / n_remote_calls)
+        # Chain-ACK share — float arithmetic is ~100x cheaper than Fraction.
+        # The string round-trip preserves wire compatibility with the existing
+        # `_handle_ack` / `add_ack_fraction_str` decoder.
+        new_share_fraction: str = repr(float(ack_share) / n_remote_calls)
         if is_root:
             # This is the root
             ack_host = self.__networking.host_name

--- a/styx-package/styx/common/stateful_function.py
+++ b/styx-package/styx/common/stateful_function.py
@@ -38,7 +38,6 @@ class StatefulFunction(Function):
         t_id: int,
         request_id: bytes,
         fallback_mode: bool,
-        use_fallback_cache: bool,
         deployed_graph: StateflowGraph,
         operator_lock: asyncio.Lock,
         protocol: BaseTransactionalProtocol,
@@ -56,7 +55,6 @@ class StatefulFunction(Function):
             t_id (int): Transaction ID.
             request_id (bytes): Unique identifier for this function invocation.
             fallback_mode (bool): Whether to enable fallback (recovery) logic.
-            use_fallback_cache (bool): Whether to use cached fallback results.
             partitioner (BasePartitioner): The partitioning strategy.
             protocol (BaseTransactionalProtocol): Protocol for function invocation.
         """
@@ -69,20 +67,19 @@ class StatefulFunction(Function):
         self.__request_id: bytes = request_id
         self.__async_remote_calls: list[tuple[str, str, int, object, tuple, bool]] = []
         self.__fallback_enabled: bool = fallback_mode
-        self.__use_fallback_cache: bool = use_fallback_cache
         self.__key = key
         self.__protocol = protocol
         self.__partition = partition
         self.__deployed_graph = deployed_graph
         self.__operator_lock: asyncio.Lock = operator_lock
 
-    async def __call__(self, *args, **kwargs) -> tuple[object, int, int]:  # noqa: ANN002, ANN003
+    async def __call__(self, *args, **kwargs) -> tuple[object, int]:  # noqa: ANN002, ANN003
         """
         Executes the wrapped function and triggers asynchronous remote calls if needed.
 
         Returns:
-            (result, n_remote_calls, partial_node_count) on success
-            (exception, -1, -1) on failure
+            (result, n_remote_calls) on success
+            (exception, -1) on failure
         """
         try:
             # 1) Decide whether we need to fetch/migrate the key, while holding the lock briefly.
@@ -141,23 +138,16 @@ class StatefulFunction(Function):
             async with self.__operator_lock:
                 res = await self.run(*args)
 
-            # 4) Fallback cache short-circuit.
-            if self.__fallback_enabled and self.__use_fallback_cache:
-                return res, len(self.__async_remote_calls), -1
-
-            # 5) Chain / async remote calls.
-            partial_node_count = 0
+            # 4) Chain / async remote calls.
             n_remote_calls = 0
 
             if "ack_share" in kwargs and "ack_host" in kwargs:
                 # Middle of the chain
-                partial_node_count = kwargs.get("partial_node_count", 0)
                 n_remote_calls = await self.__send_async_calls(
                     ack_host=kwargs["ack_host"],
                     ack_port=kwargs["ack_port"],
                     ack_share=kwargs["ack_share"],
                     chain_participants=kwargs["chain_participants"],
-                    partial_node_count=partial_node_count,
                 )
             elif self.__async_remote_calls:
                 # Start of the chain
@@ -166,14 +156,13 @@ class StatefulFunction(Function):
                     ack_port=-1,
                     ack_share=1,
                     chain_participants=[],
-                    partial_node_count=partial_node_count,
                     is_root=True,
                 )
 
         except Exception as e:
-            return e, -1, -1
+            return e, -1
         else:
-            return res, n_remote_calls, partial_node_count
+            return res, n_remote_calls
 
     @property
     def data(self) -> dict[K, V]:
@@ -251,7 +240,6 @@ class StatefulFunction(Function):
         ack_port: int,
         ack_share: int,
         chain_participants: list[int],
-        partial_node_count: int,
         is_root: bool = False,
     ) -> int:
         """Sends all pending asynchronous remote function calls.
@@ -261,7 +249,6 @@ class StatefulFunction(Function):
             ack_port: Port for acknowledgement callbacks.
             ack_share: Fractional contribution for chain tracking.
             chain_participants (list[int]): Workers involved in this chain.
-            partial_node_count (int): Partial chain node count.
             is_root (bool, optional): Whether this function is the chain root.
 
         Returns:
@@ -270,27 +257,23 @@ class StatefulFunction(Function):
         n_remote_calls: int = len(self.__async_remote_calls)
         if n_remote_calls == 0:
             return n_remote_calls
-        # if fallback is enabled there is no need to call the functions because they are already cached
         new_share_fraction: str = str(fractions.Fraction(ack_share) / n_remote_calls)
         if is_root:
             # This is the root
             ack_host = self.__networking.host_name
             ack_port = self.__networking.host_port
             self.__networking.prepare_function_chain(self.__t_id)
-        else:
-            if not self.__networking.in_the_same_network(ack_host, ack_port):
-                chain_participants.append(self.__networking.worker_id)
-            partial_node_count += 1
+        elif not self.__networking.in_the_same_network(ack_host, ack_port):
+            chain_participants.append(self.__networking.worker_id)
         remote_calls: list[Awaitable] = []
         for entry in self.__async_remote_calls:
             operator_name, function_name, partition, key, params, is_local = entry
-            ack_payload: tuple[str, int, int, str, list[int], int] = (
+            ack_payload: tuple[str, int, int, str, list[int]] = (
                 ack_host,
                 ack_port,
                 self.__t_id,
                 new_share_fraction,
                 chain_participants,
-                partial_node_count,
             )
             if is_local:
                 payload = RunFuncPayload(
@@ -303,7 +286,6 @@ class StatefulFunction(Function):
                     ack_payload=ack_payload,
                 )
                 if self.__fallback_enabled:
-                    # and no cache
                     remote_calls.append(
                         self.__protocol.run_fallback_function(
                             t_id=self.__t_id,
@@ -314,8 +296,6 @@ class StatefulFunction(Function):
                     remote_calls.append(
                         self.__protocol.run_function(t_id=self.__t_id, payload=payload),
                     )
-                    # add to cache
-                    self.__networking.add_remote_function_call(self.__t_id, payload)
             else:
                 remote_calls.append(
                     self.__call_remote_function_no_response(
@@ -327,7 +307,6 @@ class StatefulFunction(Function):
                         ack_payload=ack_payload,
                     ),
                 )
-            partial_node_count = 0
         await asyncio.gather(*remote_calls)
         return n_remote_calls
 
@@ -367,7 +346,7 @@ class StatefulFunction(Function):
         key: K,
         partition: int,
         params: tuple = (),
-        ack_payload: tuple[str, int, int, str, list[int], int] | None = None,
+        ack_payload: tuple[str, int, int, str, list[int]] | None = None,
     ) -> None:
         """Sends a remote function call without expecting a response.
 
@@ -404,7 +383,7 @@ class StatefulFunction(Function):
         function_name: str,
         partition: int,
         params: tuple,
-        ack_payload: tuple[str, int, int, str, list[int], int] | None = None,
+        ack_payload: tuple[str, int, int, str, list[int]] | None = None,
     ) -> tuple[tuple[int, bytes, str, str, K, int, bool, tuple], str, int] | None:
         """Prepares the payload and routing details for a remote function call.
 

--- a/styx-package/styx/common/stateful_function.py
+++ b/styx-package/styx/common/stateful_function.py
@@ -286,10 +286,17 @@ class StatefulFunction(Function):
                     ack_payload=ack_payload,
                 )
                 if self.__fallback_enabled:
+                    # internal=True: this is a chain participant, not the root.
+                    # The root is already running run_fallback_function for this
+                    # t_id and awaiting waited_ack_events[t_id]; if we entered
+                    # the non-internal path here we'd recursively wait on the
+                    # same event from inside the gather that's supposed to set
+                    # it, deadlocking fallback.
                     remote_calls.append(
                         self.__protocol.run_fallback_function(
                             t_id=self.__t_id,
                             payload=payload,
+                            internal=True,
                         ),
                     )
                 else:

--- a/styx-package/styx/common/util/aio_task_scheduler.py
+++ b/styx-package/styx/common/util/aio_task_scheduler.py
@@ -56,6 +56,31 @@ class AIOTaskScheduler:
         task.add_done_callback(self._on_done)
         return
 
+    def create_unbounded_task(self, coroutine: Awaitable) -> None:
+        """
+        Schedule a coroutine without taking a concurrency slot.
+
+        Use for tasks whose dominant time is `await event.wait()` and that
+        therefore must NOT hold a semaphore slot while suspended — otherwise
+        they starve other tasks waiting on those very events. Concretely, this
+        is the fix for the fallback chain-participant deadlock: many
+        participants suspend on `fallback_locking_event_map[d]`, those events
+        only fire when other participants (queued behind the semaphore) get to
+        run, so the sleeping ones must release the slot.
+
+        Still strongly references the task — `asyncio.create_task` only keeps
+        a weak ref via the event loop, and a suspended task with no other
+        strong ref can be GC'd mid-await.
+        """
+        if self.closed:
+            logging.warning("Trying to create a task in a closed AIOTaskScheduler!")
+            return
+
+        task = asyncio.create_task(coroutine)
+        self.background_tasks.add(task)
+        task.add_done_callback(self._on_done)
+        return
+
     async def close(self) -> None:
         """
         Stop accepting new tasks, cancel all running/queued tasks, and wait for them.

--- a/tests/e2e/test_e2e_deathstar_hotel_reservation.py
+++ b/tests/e2e/test_e2e_deathstar_hotel_reservation.py
@@ -39,7 +39,6 @@ class _ClusterParams:
     threads_per_worker: int = 1
     enable_compression: str = "true"
     use_composite_keys: str = "true"
-    use_fallback_cache: str = "true"
 
 
 @dataclass(frozen=True)
@@ -93,7 +92,6 @@ def _start_cmd(paths: _Paths, p: _ClusterParams) -> list[str]:
         str(p.threads_per_worker),
         p.enable_compression,
         p.use_composite_keys,
-        p.use_fallback_cache,
     ]
 
 

--- a/tests/e2e/test_e2e_deathstar_movie_review.py
+++ b/tests/e2e/test_e2e_deathstar_movie_review.py
@@ -39,7 +39,6 @@ class _ClusterParams:
     threads_per_worker: int = 1
     enable_compression: str = "true"
     use_composite_keys: str = "true"
-    use_fallback_cache: str = "true"
 
 
 @dataclass(frozen=True)
@@ -93,7 +92,6 @@ def _start_cmd(paths: _Paths, p: _ClusterParams) -> list[str]:
         str(p.threads_per_worker),
         p.enable_compression,
         p.use_composite_keys,
-        p.use_fallback_cache,
     ]
 
 

--- a/tests/e2e/test_e2e_migration_tpcc.py
+++ b/tests/e2e/test_e2e_migration_tpcc.py
@@ -41,7 +41,6 @@ class _ClusterParams:
     threads_per_worker: int = 1
     enable_compression: str = "true"
     use_composite_keys: str = "true"
-    use_fallback_cache: str = "true"
 
 
 @dataclass(frozen=True)
@@ -98,7 +97,6 @@ def _start_cmd(paths: _Paths, p: _ClusterParams) -> list[str]:
         str(p.threads_per_worker),
         p.enable_compression,
         p.use_composite_keys,
-        p.use_fallback_cache,
     ]
 
 
@@ -118,7 +116,6 @@ def _client_cmd(results_dir: Path, cluster: _ClusterParams, client: _ClientParam
     #  8  N_W
     #  9  enable_compression
     # 10  use_composite_keys
-    # 11  use_fallback_cache
     return [
         "python",
         "pure_kafka_demo.py",
@@ -132,7 +129,6 @@ def _client_cmd(results_dir: Path, cluster: _ClusterParams, client: _ClientParam
         str(client.n_warehouses),
         cluster.enable_compression,
         cluster.use_composite_keys,
-        cluster.use_fallback_cache,
     ]
 
 

--- a/tests/e2e/test_e2e_migration_ycsb.py
+++ b/tests/e2e/test_e2e_migration_ycsb.py
@@ -39,7 +39,6 @@ class _ClusterParams:
     threads_per_worker: int = 1
     enable_compression: str = "true"
     use_composite_keys: str = "true"
-    use_fallback_cache: str = "true"
 
 
 @dataclass(frozen=True)
@@ -95,7 +94,6 @@ def _start_cmd(paths: _Paths, p: _ClusterParams) -> list[str]:
         str(p.threads_per_worker),
         p.enable_compression,
         p.use_composite_keys,
-        p.use_fallback_cache,
     ]
 
 

--- a/tests/e2e/test_e2e_tpcc.py
+++ b/tests/e2e/test_e2e_tpcc.py
@@ -40,7 +40,6 @@ class _ClusterParams:
     threads_per_worker: int = 1
     enable_compression: str = "true"
     use_composite_keys: str = "true"
-    use_fallback_cache: str = "true"
 
 
 @dataclass(frozen=True)
@@ -97,7 +96,6 @@ def _start_cmd(paths: _Paths, p: _ClusterParams) -> list[str]:
         str(p.threads_per_worker),
         p.enable_compression,
         p.use_composite_keys,
-        p.use_fallback_cache,
     ]
 
 
@@ -116,8 +114,7 @@ def _client_cmd(results_dir: Path, cluster: _ClusterParams, client: _ClientParam
     #  7  N_W
     #  8  enable_compression
     #  9  use_composite_keys
-    # 10  use_fallback_cache
-    # 11  kill_at (optional; default -1)
+    # 10  kill_at (optional; default -1)
     return [
         "python",
         "pure_kafka_demo.py",
@@ -130,7 +127,6 @@ def _client_cmd(results_dir: Path, cluster: _ClusterParams, client: _ClientParam
         str(client.n_warehouses),
         cluster.enable_compression,
         cluster.use_composite_keys,
-        cluster.use_fallback_cache,
         str(client.kill_at),
     ]
 

--- a/tests/e2e/test_e2e_ycsb.py
+++ b/tests/e2e/test_e2e_ycsb.py
@@ -46,7 +46,6 @@ class _ClusterParams:
     threads_per_worker: int = 1
     enable_compression: str = "true"
     use_composite_keys: str = "true"
-    use_fallback_cache: str = "true"
 
 
 @dataclass(frozen=True)
@@ -103,7 +102,6 @@ def _start_cmd(paths: _Paths, p: _ClusterParams) -> list[str]:
         str(p.threads_per_worker),
         p.enable_compression,
         p.use_composite_keys,
-        p.use_fallback_cache,
     ]
 
 

--- a/tests/unit/styx_package/test_aio_task_scheduler.py
+++ b/tests/unit/styx_package/test_aio_task_scheduler.py
@@ -80,6 +80,66 @@ class TestAIOTaskSchedulerCreateTask:
         assert max_active[0] <= 2
 
 
+class TestAIOTaskSchedulerCreateUnboundedTask:
+    @pytest.mark.asyncio
+    async def test_runs_without_consuming_semaphore_slot(self):
+        """Unbounded tasks must not consume a semaphore slot — otherwise
+        long-suspended unbounded tasks would still starve bounded ones."""
+        s = AIOTaskScheduler(max_concurrency=1)
+        gate = asyncio.Event()
+        ran = []
+
+        async def waiter():
+            ran.append("waiter-start")
+            await gate.wait()
+            ran.append("waiter-end")
+
+        async def bounded():
+            ran.append("bounded")
+
+        s.create_unbounded_task(waiter())
+        s.create_task(bounded())
+        # Bounded task should run even though waiter is suspended,
+        # because waiter is unbounded and didn't take the slot.
+        await asyncio.sleep(0.05)
+        assert "bounded" in ran
+        assert "waiter-start" in ran
+        assert "waiter-end" not in ran
+        gate.set()
+        await s.wait_all()
+        assert "waiter-end" in ran
+
+    @pytest.mark.asyncio
+    async def test_strongly_references_task(self):
+        """Unbounded tasks must be tracked so they don't get GC'd mid-await
+        (Python only weak-refs tasks from `asyncio.create_task`)."""
+        s = AIOTaskScheduler()
+        done = []
+
+        async def worker():
+            await asyncio.sleep(0.01)
+            done.append(1)
+
+        s.create_unbounded_task(worker())
+        assert len(s.background_tasks) == 1
+        await s.wait_all()
+        assert done == [1]
+        assert len(s.background_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_closed_scheduler_ignores_unbounded(self):
+        s = AIOTaskScheduler()
+        await s.close()
+        ran = []
+
+        async def worker():
+            ran.append(1)
+
+        s.create_unbounded_task(worker())
+        await asyncio.sleep(0.05)
+        assert ran == []
+
+
 class TestAIOTaskSchedulerClose:
     @pytest.mark.asyncio
     async def test_close_cancels_tasks(self):

--- a/tests/unit/styx_package/test_base_networking.py
+++ b/tests/unit/styx_package/test_base_networking.py
@@ -6,7 +6,6 @@ event loop.  We make those tests ``async`` so that pytest-asyncio
 """
 
 import asyncio
-import fractions
 from unittest.mock import patch
 
 import pytest
@@ -106,7 +105,7 @@ class TestCleanupAfterEpoch:
     async def test_clears_all_dicts(self):
         n = _net()
         n.waited_ack_events[1] = asyncio.Event()
-        n.ack_fraction[1] = fractions.Fraction(1, 2)
+        n.ack_fraction[1] = 0.5
         n.aborted_events[1] = "err"
         n.logic_aborts_everywhere.add(1)
         n.chain_participants[1] = [2]
@@ -133,14 +132,14 @@ class TestFunctionChain:
         n.prepare_function_chain(10)
         assert 10 in n.waited_ack_events
         assert isinstance(n.waited_ack_events[10], asyncio.Event)
-        assert n.ack_fraction[10] == fractions.Fraction(0)
+        assert n.ack_fraction[10] == 0.0
 
     async def test_add_ack_fraction_completes_at_1(self):
         n = _net()
         n.prepare_function_chain(10)
-        n.add_ack_fraction_str(10, "1/2", [])
+        n.add_ack_fraction_str(10, "0.5", [])
         assert not n.waited_ack_events[10].is_set()
-        n.add_ack_fraction_str(10, "1/2", [])
+        n.add_ack_fraction_str(10, "0.5", [])
         assert n.waited_ack_events[10].is_set()
 
     async def test_add_ack_fraction_skips_aborted(self):
@@ -149,7 +148,7 @@ class TestFunctionChain:
         n.aborted_events[10] = "err"
         n.add_ack_fraction_str(10, "1", [])
         # Should not set the event (aborted early return)
-        assert n.ack_fraction[10] == fractions.Fraction(0)
+        assert n.ack_fraction[10] == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -162,10 +161,10 @@ class TestResetAck:
         n = _net()
         n.prepare_function_chain(10)
         n.waited_ack_events[10].set()
-        n.ack_fraction[10] = fractions.Fraction(1)
+        n.ack_fraction[10] = 1.0
         n.reset_ack_for_fallback(10)
         assert not n.waited_ack_events[10].is_set()
-        assert n.ack_fraction[10] == fractions.Fraction(0)
+        assert n.ack_fraction[10] == 0.0
 
     def test_reset_for_fallback_missing_id(self):
         n = _net()
@@ -325,18 +324,20 @@ class TestEncodeDecodeMessage:
 
 
 class TestAddAckFractionStrEdgeCases:
-    async def test_fraction_exceeds_one_logs_error(self):
+    async def test_fraction_at_one_sets_event(self):
         n = _net()
         n.prepare_function_chain(10)
-        n.add_ack_fraction_str(10, "1/2", [])
-        n.add_ack_fraction_str(10, "3/4", [])
-        # fraction is 1/2 + 3/4 = 5/4 > 1, should log but not crash
+        n.add_ack_fraction_str(10, "0.5", [])
+        assert not n.waited_ack_events[10].is_set()
+        n.add_ack_fraction_str(10, "0.75", [])
+        # 0.5 + 0.75 = 1.25 >= 1.0 - eps, event fires
+        assert n.waited_ack_events[10].is_set()
         assert n.ack_fraction[10] > 1
 
     async def test_fraction_key_error_on_missing_tid(self):
         n = _net()
         # Don't prepare chain — ack_fraction[99] does not exist
-        n.add_ack_fraction_str(99, "1/2", [])
+        n.add_ack_fraction_str(99, "0.5", [])
         # Should not raise; handled internally via KeyError
 
 

--- a/tests/unit/styx_package/test_base_networking.py
+++ b/tests/unit/styx_package/test_base_networking.py
@@ -7,13 +7,12 @@ event loop.  We make those tests ``async`` so that pytest-asyncio
 
 import asyncio
 import fractions
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from styx.common.base_networking import BaseNetworking, MessagingMode
 from styx.common.exceptions import SerializerNotSupportedError
 from styx.common.message_types import MessageType
-from styx.common.run_func_payload import RunFuncPayload
 from styx.common.serialization import Serializer
 
 # ---------------------------------------------------------------------------
@@ -63,7 +62,6 @@ class TestBaseNetworkingInit:
         n = _net()
         assert n.waited_ack_events == {}
         assert n.ack_fraction == {}
-        assert n.ack_cnts == {}
         assert len(n.aborted_events) == 0
         assert len(n.logic_aborts_everywhere) == 0
 
@@ -109,9 +107,7 @@ class TestCleanupAfterEpoch:
         n = _net()
         n.waited_ack_events[1] = asyncio.Event()
         n.ack_fraction[1] = fractions.Fraction(1, 2)
-        n.ack_cnts[1] = (1, 2)
         n.aborted_events[1] = "err"
-        n.remote_function_calls[1] = [MagicMock()]
         n.logic_aborts_everywhere.add(1)
         n.chain_participants[1] = [2]
         n.client_responses[1] = "resp"
@@ -120,38 +116,14 @@ class TestCleanupAfterEpoch:
 
         assert len(n.waited_ack_events) == 0
         assert len(n.ack_fraction) == 0
-        assert len(n.ack_cnts) == 0
         assert len(n.aborted_events) == 0
-        assert len(n.remote_function_calls) == 0
         assert len(n.logic_aborts_everywhere) == 0
         assert len(n.chain_participants) == 0
         assert len(n.client_responses) == 0
 
 
 # ---------------------------------------------------------------------------
-# add_remote_function_call
-# ---------------------------------------------------------------------------
-
-
-class TestAddRemoteFunctionCall:
-    def test_appends_payload(self):
-        n = _net()
-        p = RunFuncPayload(request_id=b"r", key="k", operator_name="op", partition=0, function_name="fn", params=())
-        n.add_remote_function_call(1, p)
-        assert len(n.remote_function_calls[1]) == 1
-        assert n.remote_function_calls[1][0] is p
-
-    def test_multiple_payloads(self):
-        n = _net()
-        p1 = RunFuncPayload(request_id=b"r1", key="k1", operator_name="op", partition=0, function_name="fn", params=())
-        p2 = RunFuncPayload(request_id=b"r2", key="k2", operator_name="op", partition=0, function_name="fn", params=())
-        n.add_remote_function_call(1, p1)
-        n.add_remote_function_call(1, p2)
-        assert len(n.remote_function_calls[1]) == 2
-
-
-# ---------------------------------------------------------------------------
-# prepare_function_chain / ack_fraction / ack_cnt  (needs loop)
+# prepare_function_chain / ack_fraction  (needs loop)
 # ---------------------------------------------------------------------------
 
 
@@ -162,40 +134,22 @@ class TestFunctionChain:
         assert 10 in n.waited_ack_events
         assert isinstance(n.waited_ack_events[10], asyncio.Event)
         assert n.ack_fraction[10] == fractions.Fraction(0)
-        assert n.ack_cnts[10] == (0, 0)
 
     async def test_add_ack_fraction_completes_at_1(self):
         n = _net()
         n.prepare_function_chain(10)
-        n.add_ack_fraction_str(10, "1/2", [], 0)
+        n.add_ack_fraction_str(10, "1/2", [])
         assert not n.waited_ack_events[10].is_set()
-        n.add_ack_fraction_str(10, "1/2", [], 0)
+        n.add_ack_fraction_str(10, "1/2", [])
         assert n.waited_ack_events[10].is_set()
 
     async def test_add_ack_fraction_skips_aborted(self):
         n = _net()
         n.prepare_function_chain(10)
         n.aborted_events[10] = "err"
-        n.add_ack_fraction_str(10, "1", [], 0)
+        n.add_ack_fraction_str(10, "1", [])
         # Should not set the event (aborted early return)
         assert n.ack_fraction[10] == fractions.Fraction(0)
-
-    async def test_add_ack_cnt(self):
-        n = _net()
-        n.prepare_function_chain(10)
-        n.ack_cnts[10] = (0, 2)
-        n.add_ack_cnt(10, 1)
-        assert n.ack_cnts[10] == (1, 2)
-        assert not n.waited_ack_events[10].is_set()
-        n.add_ack_cnt(10, 1)
-        assert n.waited_ack_events[10].is_set()
-
-    async def test_add_ack_cnt_skips_aborted(self):
-        n = _net()
-        n.prepare_function_chain(10)
-        n.aborted_events[10] = "err"
-        n.add_ack_cnt(10, 1)
-        assert n.ack_cnts[10] == (0, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -216,15 +170,6 @@ class TestResetAck:
     def test_reset_for_fallback_missing_id(self):
         n = _net()
         n.reset_ack_for_fallback(999)  # should not raise
-
-    async def test_reset_for_fallback_cache(self):
-        n = _net()
-        n.prepare_function_chain(10)
-        n.waited_ack_events[10].set()
-        n.reset_ack_for_fallback_cache(10)
-        assert not n.waited_ack_events[10].is_set()
-        # fraction NOT reset in cache mode
-        assert n.ack_fraction[10] == fractions.Fraction(0)
 
 
 # ---------------------------------------------------------------------------
@@ -383,41 +328,16 @@ class TestAddAckFractionStrEdgeCases:
     async def test_fraction_exceeds_one_logs_error(self):
         n = _net()
         n.prepare_function_chain(10)
-        n.add_ack_fraction_str(10, "1/2", [], 0)
-        n.add_ack_fraction_str(10, "3/4", [], 0)
+        n.add_ack_fraction_str(10, "1/2", [])
+        n.add_ack_fraction_str(10, "3/4", [])
         # fraction is 1/2 + 3/4 = 5/4 > 1, should log but not crash
         assert n.ack_fraction[10] > 1
 
     async def test_fraction_key_error_on_missing_tid(self):
         n = _net()
         # Don't prepare chain — ack_fraction[99] does not exist
-        n.add_ack_fraction_str(99, "1/2", [], 0)
+        n.add_ack_fraction_str(99, "1/2", [])
         # Should not raise; handled internally via KeyError
-
-    async def test_partial_node_count_accumulates(self):
-        n = _net()
-        n.prepare_function_chain(10)
-        n.add_ack_fraction_str(10, "1/4", [1], 2)
-        assert n.ack_cnts[10] == (0, 2)
-        n.add_ack_fraction_str(10, "1/4", [2], 3)
-        assert n.ack_cnts[10] == (0, 5)
-
-
-class TestAddAckCntEdgeCases:
-    async def test_cnt_exceeds_total_logs_error(self):
-        n = _net()
-        n.prepare_function_chain(10)
-        n.ack_cnts[10] = (0, 1)
-        n.add_ack_cnt(10, 1)
-        assert n.waited_ack_events[10].is_set()
-        # Adding more exceeds total
-        n.waited_ack_events[10].clear()
-        n.add_ack_cnt(10, 1)
-        assert n.ack_cnts[10] == (2, 1)  # 2 > 1
-
-    async def test_cnt_key_error_on_missing_tid(self):
-        n = _net()
-        n.add_ack_cnt(99, 1)  # should not raise
 
 
 class TestAddResponseNone:

--- a/tests/unit/styx_package/test_message_types.py
+++ b/tests/unit/styx_package/test_message_types.py
@@ -10,15 +10,17 @@ class TestMessageType:
         assert issubclass(MessageType, IntEnum)
 
     def test_total_count(self):
-        assert len(MessageType) == 42
+        assert len(MessageType) == 41
 
     def test_all_values_unique(self):
         values = [m.value for m in MessageType]
         assert len(values) == len(set(values))
 
-    def test_values_are_contiguous_from_zero(self):
+    def test_values_in_expected_range(self):
+        # 25 (AckCache) was removed when the fallback cache was dropped; the
+        # remaining IDs are preserved to keep wire-format stability.
         values = sorted(m.value for m in MessageType)
-        assert values == list(range(42))
+        assert values == [v for v in range(42) if v != 25]
 
     def test_known_values(self):
         assert MessageType.RunFunRemote == 0

--- a/tests/unit/styx_package/test_operator.py
+++ b/tests/unit/styx_package/test_operator.py
@@ -181,7 +181,6 @@ class TestRunFunctionErrors:
                     partition=0,
                     ack_payload=None,
                     fallback_mode=False,
-                    use_fallback_cache=False,
                     params=(),
                     protocol=None,
                 )

--- a/tests/unit/styx_package/test_operator_coverage.py
+++ b/tests/unit/styx_package/test_operator_coverage.py
@@ -30,9 +30,7 @@ def _mock_networking(same_network=False):
     n.add_response = MagicMock()
     n.abort_chain = MagicMock()
     n.add_ack_fraction_str = MagicMock()
-    n.add_ack_cnt = MagicMock()
     n.prepare_function_chain = MagicMock()
-    n.add_remote_function_call = MagicMock()
     return n
 
 
@@ -113,7 +111,6 @@ class TestMaterializeFunctionError:
                 partition=0,
                 ack_payload=None,
                 fallback_mode=False,
-                use_fallback_cache=False,
                 params=(),
                 protocol=protocol,
             )
@@ -153,7 +150,6 @@ class TestRunFunctionRoot:
             partition=0,
             ack_payload=None,
             fallback_mode=False,
-            use_fallback_cache=False,
             params=(),
             protocol=protocol,
         )
@@ -177,7 +173,6 @@ class TestRunFunctionRoot:
             partition=0,
             ack_payload=None,
             fallback_mode=False,
-            use_fallback_cache=False,
             params=(),
             protocol=protocol,
         )
@@ -205,7 +200,6 @@ class TestRunFunctionRoot:
             partition=0,
             ack_payload=None,
             fallback_mode=False,
-            use_fallback_cache=False,
             params=(),
             protocol=protocol,
         )
@@ -223,7 +217,7 @@ class TestRunFunctionChain:
     async def test_chain_success_sends_ack_local(self):
         op, _state, networking, _graph = _setup_operator(same_network=True)
         protocol = _mock_protocol()
-        ack_payload = ("10.0.0.1", 6000, 1, "1/1", [], 0)
+        ack_payload = ("10.0.0.1", 6000, 1, "1/1", [])
         result = await op.run_function(
             key="k1",
             t_id=1,
@@ -232,7 +226,6 @@ class TestRunFunctionChain:
             partition=0,
             ack_payload=ack_payload,
             fallback_mode=False,
-            use_fallback_cache=False,
             params=(),
             protocol=protocol,
         )
@@ -243,7 +236,7 @@ class TestRunFunctionChain:
     async def test_chain_success_sends_ack_remote(self):
         op, _state, networking, _graph = _setup_operator(same_network=False)
         protocol = _mock_protocol()
-        ack_payload = ("10.0.0.2", 6001, 1, "1/1", [], 0)
+        ack_payload = ("10.0.0.2", 6001, 1, "1/1", [])
         result = await op.run_function(
             key="k1",
             t_id=1,
@@ -252,7 +245,6 @@ class TestRunFunctionChain:
             partition=0,
             ack_payload=ack_payload,
             fallback_mode=False,
-            use_fallback_cache=False,
             params=(),
             protocol=protocol,
         )
@@ -268,7 +260,7 @@ class TestRunFunctionChain:
             return ValueError("chain_error")
 
         op.register(bad_func)
-        ack_payload = ("10.0.0.1", 6000, 1, "1/1", [], 0)
+        ack_payload = ("10.0.0.1", 6000, 1, "1/1", [])
         result = await op.run_function(
             key="k1",
             t_id=1,
@@ -277,7 +269,6 @@ class TestRunFunctionChain:
             partition=0,
             ack_payload=ack_payload,
             fallback_mode=False,
-            use_fallback_cache=False,
             params=(),
             protocol=protocol,
         )
@@ -337,53 +328,3 @@ class TestSetNPartitions:
         op = _operator(n_partitions=2)
         op.set_n_partitions(4)
         assert op.n_partitions == 4
-
-
-# ---------------------------------------------------------------------------
-# Fallback cache ack
-# ---------------------------------------------------------------------------
-
-
-class TestFallbackCacheAck:
-    @pytest.mark.asyncio
-    async def test_chain_fallback_cache_sends_cache_ack_local(self):
-        op, _state, networking, _graph = _setup_operator(same_network=True)
-        protocol = _mock_protocol()
-        ack_payload = ("10.0.0.1", 6000, 1, "1/1", [], 0)
-        result = await op.run_function(
-            key="k1",
-            t_id=1,
-            request_id=b"req",
-            function_name="my_func",
-            partition=0,
-            ack_payload=ack_payload,
-            fallback_mode=True,
-            use_fallback_cache=True,
-            params=(),
-            protocol=protocol,
-        )
-        assert result is True
-        networking.add_ack_cnt.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_chain_fallback_cache_sends_cache_ack_remote(self):
-        op, _state, networking, _graph = _setup_operator(same_network=False)
-        protocol = _mock_protocol()
-        ack_payload = ("10.0.0.2", 6001, 1, "1/1", [], 0)
-        result = await op.run_function(
-            key="k1",
-            t_id=1,
-            request_id=b"req",
-            function_name="my_func",
-            partition=0,
-            ack_payload=ack_payload,
-            fallback_mode=True,
-            use_fallback_cache=True,
-            params=(),
-            protocol=protocol,
-        )
-        assert result is True
-        # Should send both AckCache and ResponseToRoot (because resp is not None)
-        assert networking.send_message.call_count >= 1
-        msg_types = [c[1]["msg_type"] for c in networking.send_message.call_args_list]
-        assert MessageType.AckCache in msg_types

--- a/tests/unit/styx_package/test_stateful_function.py
+++ b/tests/unit/styx_package/test_stateful_function.py
@@ -17,7 +17,6 @@ def _make_sf(
     partition=0,
     operator_name="users",
     fallback_mode=False,
-    use_fallback_cache=False,
 ):
     """Creates a StatefulFunction with mocked dependencies."""
     state = MagicMock()
@@ -48,7 +47,6 @@ def _make_sf(
         t_id=t_id,
         request_id=request_id,
         fallback_mode=fallback_mode,
-        use_fallback_cache=use_fallback_cache,
         deployed_graph=graph,
         operator_lock=lock,
         protocol=protocol,
@@ -170,10 +168,9 @@ class TestStatefulFunctionCall:
         sf, state, *_ = _make_sf()
         state.in_remote_keys.return_value = False
         # run() is not implemented on the base class
-        result, n_calls, partial = await sf()
+        result, n_calls = await sf()
         assert isinstance(result, NotImplementedError)
         assert n_calls == -1
-        assert partial == -1
 
     @pytest.mark.asyncio
     async def test_call_with_no_remote_keys(self):
@@ -185,10 +182,9 @@ class TestStatefulFunctionCall:
             return "success"
 
         sf.run = mock_run
-        result, n_calls, partial = await sf()
+        result, n_calls = await sf()
         assert result == "success"
         assert n_calls == 0
-        assert partial == 0
 
     @pytest.mark.asyncio
     async def test_call_local_migration(self):
@@ -201,7 +197,7 @@ class TestStatefulFunctionCall:
             return "migrated"
 
         sf.run = mock_run
-        result, _n_calls, _partial = await sf()
+        result, _n_calls = await sf()
         state.migrate_within_the_same_worker.assert_called_once_with("users", 0, "k1", 1)
         assert result == "migrated"
 
@@ -219,20 +215,7 @@ class TestStatefulFunctionCall:
             return "remote_migrated"
 
         sf.run = mock_run
-        result, _n_calls, _partial = await sf()
+        result, _n_calls = await sf()
         networking.request_key.assert_called_once()
         networking.wait_for_remote_key_event.assert_called_once()
         assert result == "remote_migrated"
-
-    @pytest.mark.asyncio
-    async def test_fallback_cache_shortcircuit(self):
-        sf, state, *_ = _make_sf(fallback_mode=True, use_fallback_cache=True)
-        state.in_remote_keys.return_value = False
-
-        async def mock_run(*args):
-            return "cached"
-
-        sf.run = mock_run
-        result, _n_calls, partial = await sf()
-        assert result == "cached"
-        assert partial == -1

--- a/tests/unit/styx_package/test_stateful_function_coverage.py
+++ b/tests/unit/styx_package/test_stateful_function_coverage.py
@@ -1,7 +1,7 @@
 """Additional coverage tests for styx/common/stateful_function.py
 
 Focuses on: __prepare_message_transmission, __call_remote_function_no_response,
-__send_async_calls (local vs remote, root vs middle chain), partial_node_count kwargs.
+__send_async_calls (local vs remote, root vs middle chain).
 """
 
 import asyncio
@@ -21,7 +21,6 @@ def _make_sf(
     partition=0,
     operator_name="users",
     fallback_mode=False,
-    use_fallback_cache=False,
     same_network=False,
 ):
     state = MagicMock()
@@ -33,7 +32,6 @@ def _make_sf(
     networking.in_the_same_network = MagicMock(return_value=same_network)
     networking.send_message = AsyncMock()
     networking.prepare_function_chain = MagicMock()
-    networking.add_remote_function_call = MagicMock()
     dns = {
         "users": {0: ("10.0.0.1", 5000, 6000), 1: ("10.0.0.2", 5001, 6001)},
         "orders": {0: ("10.0.0.3", 5002, 6002)},
@@ -62,7 +60,6 @@ def _make_sf(
         t_id=t_id,
         request_id=request_id,
         fallback_mode=fallback_mode,
-        use_fallback_cache=use_fallback_cache,
         deployed_graph=graph,
         operator_lock=lock,
         protocol=protocol,
@@ -91,7 +88,7 @@ class TestPrepareMessageTransmission:
 
     def test_payload_with_ack(self):
         sf, *_ = _make_sf()
-        ack = ("h", 5000, 1, "1/2", [], 0)
+        ack = ("h", 5000, 1, "1/2", [])
         result = sf._StatefulFunction__prepare_message_transmission("users", "k1", "my_func", 0, (), ack)
         payload, _, _ = result
         assert len(payload) == 9  # base 8 + ack tuple
@@ -118,7 +115,7 @@ class TestCallRemoteFunctionNoResponse:
             key="k1",
             partition=0,
             params=(1,),
-            ack_payload=("h", 5000, 1, "1/1", [], 0),
+            ack_payload=("h", 5000, 1, "1/1", []),
         )
         networking.send_message.assert_called_once()
 
@@ -154,7 +151,7 @@ class TestSendAsyncCallsRoot:
 
         sf.run = my_run
 
-        result, n_calls, _partial = await sf()
+        result, n_calls = await sf()
         assert result == "result"
         assert n_calls == 1
         networking.prepare_function_chain.assert_called_once_with(42)
@@ -176,36 +173,16 @@ class TestSendAsyncCallsMiddle:
 
         sf.run = my_run
 
-        result, n_calls, _partial = await sf(
+        result, n_calls = await sf(
             ack_host="10.0.0.2",
             ack_port=6001,
             ack_share="1/1",
             chain_participants=[],
-            partial_node_count=0,
         )
         assert result == "mid_result"
         assert n_calls == 1
         # Should append worker_id to chain_participants since remote
         assert networking.worker_id == 0  # sanity check
-
-    @pytest.mark.asyncio
-    async def test_middle_chain_with_partial_node_count(self):
-        sf, _state, _networking, _graph, _protocol = _make_sf(same_network=True)
-
-        async def my_run(*args):
-            sf.call_remote_async("users", "my_func", "k2")
-
-        sf.run = my_run
-
-        _result, n_calls, partial = await sf(
-            ack_host="10.0.0.1",
-            ack_port=6000,
-            ack_share="1/1",
-            chain_participants=[],
-            partial_node_count=5,
-        )
-        assert n_calls == 1
-        assert partial == 5  # partial_node_count passed through
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +196,6 @@ class TestSendAsyncCallsFallback:
         sf, _state, _networking, _graph, protocol = _make_sf(
             same_network=True,
             fallback_mode=True,
-            use_fallback_cache=False,
         )
 
         async def my_run(*args):
@@ -228,13 +204,11 @@ class TestSendAsyncCallsFallback:
 
         sf.run = my_run
 
-        # Not in cache, so async calls should run fallback
-        _result, n_calls, _partial = await sf(
+        _result, n_calls = await sf(
             ack_host="10.0.0.1",
             ack_port=6000,
             ack_share="1/1",
             chain_participants=[],
-            partial_node_count=0,
         )
         assert n_calls == 1
         protocol.run_fallback_function.assert_called_once()
@@ -255,6 +229,6 @@ class TestSendAsyncCallsEmpty:
 
         sf.run = my_run
 
-        result, n_calls, _partial = await sf()
+        result, n_calls = await sf()
         assert result == "simple"
         assert n_calls == 0

--- a/tests/unit/styx_package/test_stateful_function_coverage.py
+++ b/tests/unit/styx_package/test_stateful_function_coverage.py
@@ -115,7 +115,7 @@ class TestCallRemoteFunctionNoResponse:
             key="k1",
             partition=0,
             params=(1,),
-            ack_payload=("h", 5000, 1, "1/1", []),
+            ack_payload=("h", 5000, 1, "1", []),
         )
         networking.send_message.assert_called_once()
 
@@ -176,7 +176,7 @@ class TestSendAsyncCallsMiddle:
         result, n_calls = await sf(
             ack_host="10.0.0.2",
             ack_port=6001,
-            ack_share="1/1",
+            ack_share="1",
             chain_participants=[],
         )
         assert result == "mid_result"
@@ -207,7 +207,7 @@ class TestSendAsyncCallsFallback:
         _result, n_calls = await sf(
             ack_host="10.0.0.1",
             ack_port=6000,
-            ack_share="1/1",
+            ack_share="1",
             chain_participants=[],
         )
         assert n_calls == 1

--- a/tests/unit/worker/test_fallback_rw_set.py
+++ b/tests/unit/worker/test_fallback_rw_set.py
@@ -96,12 +96,20 @@ class TestFallbackReadSetChange:
         _fallback_read(s, "k1", t_id=1)
         assert s.has_fallback_rw_set_changed(1) is True
 
-    def test_original_reads_but_no_fallback_reads(self):
+    def test_original_reads_but_no_fallback_reads_on_existing_key(self):
         s = _state()
-        # Original read: k1
+        s.data[OP_PART]["k1"] = "v1"
         _read(s, "k1", t_id=1)
-        # No fallback reads
+        # No fallback reads. k1 is in committed state → diff is contended.
         assert s.has_fallback_rw_set_changed(1) is True
+
+    def test_original_reads_but_no_fallback_reads_on_new_key_is_safe(self):
+        """Relaxation: a diff-read on a key absent from committed state was
+        a `None`-read with no effect on the chain's outcome — treat as safe."""
+        s = _state()
+        # k1 not in s.data
+        _read(s, "k1", t_id=1)
+        assert s.has_fallback_rw_set_changed(1) is False
 
 
 # ---------------------------------------------------------------------------
@@ -118,22 +126,41 @@ class TestFallbackWriteSetChange:
         _fallback_write(s, "k1", "v1_new", t_id=1)
         assert s.has_fallback_rw_set_changed(1) is False
 
-    def test_extra_fallback_write_detected(self):
+    def test_extra_fallback_write_to_new_key_is_safe(self):
+        """Diff-write to a key absent from committed state is treated as a
+        pure insert and accepted (see relaxation in
+        has_fallback_rw_set_changed)."""
         s = _state()
-        # Original write: k1
         _put(s, "k1", "v1", t_id=1)
-        # Fallback writes: k1 and k2
         _fallback_write(s, "k1", "v1", t_id=1)
         _fallback_write(s, "k2", "v2", t_id=1)
+        # k2 not in s.data → fresh insert → safe
+        assert s.has_fallback_rw_set_changed(1) is False
+
+    def test_extra_fallback_write_to_existing_key_detected(self):
+        s = _state()
+        s.data[OP_PART]["k2"] = "preexisting"
+        _put(s, "k1", "v1", t_id=1)
+        _fallback_write(s, "k1", "v1", t_id=1)
+        _fallback_write(s, "k2", "v2_new", t_id=1)
+        # k2 already in committed state → contended diff → reschedule
         assert s.has_fallback_rw_set_changed(1) is True
 
-    def test_missing_fallback_write_detected(self):
+    def test_missing_fallback_write_to_new_key_is_safe(self):
         s = _state()
-        # Original writes: k1 and k2
         _put(s, "k1", "v1", t_id=1)
         _put(s, "k2", "v2", t_id=1)
-        # Fallback write: only k1
         _fallback_write(s, "k1", "v1", t_id=1)
+        # k2 dropped in fallback, and not yet in committed state → safe
+        assert s.has_fallback_rw_set_changed(1) is False
+
+    def test_missing_fallback_write_to_existing_key_detected(self):
+        s = _state()
+        s.data[OP_PART]["k2"] = "preexisting"
+        _put(s, "k1", "v1", t_id=1)
+        _put(s, "k2", "v2", t_id=1)
+        _fallback_write(s, "k1", "v1", t_id=1)
+        # k2 dropped in fallback but is in committed state → contended
         assert s.has_fallback_rw_set_changed(1) is True
 
     def test_different_value_same_keys_no_change(self):
@@ -150,12 +177,13 @@ class TestFallbackWriteSetChange:
 
 
 class TestFallbackCombinedRwSetChange:
-    def test_reads_same_writes_changed(self):
+    def test_reads_same_writes_changed_on_existing_key(self):
         s = _state()
         s.data[OP_PART]["k1"] = "v1"
+        s.data[OP_PART]["k3"] = "v3_old"
         _read(s, "k1", t_id=1)
         _put(s, "k2", "v2", t_id=1)
-        # Fallback: same read, but extra write
+        # Fallback: same read, extra write to k3 (which is in committed state)
         _fallback_read(s, "k1", t_id=1)
         _fallback_write(s, "k2", "v2", t_id=1)
         _fallback_write(s, "k3", "v3", t_id=1)

--- a/worker/operator_state/aria/base_aria_state.py
+++ b/worker/operator_state/aria/base_aria_state.py
@@ -180,31 +180,51 @@ class BaseAriaState(BaseOperatorState):
         optimistic execution, the fallback dependency graph is invalid and the
         transaction must be rescheduled to the next epoch.
         """
-        # Compare read sets: original vs fallback
+        from styx.common.logging import logging
+
         fallback_reads = self.fallback_read_sets.get(t_id, {})
         for op_part in self.operator_partitions:
             original_read_keys = self.read_sets[op_part].get(t_id, set())
             fallback_read_keys = fallback_reads.get(op_part, set())
             if original_read_keys != fallback_read_keys:
+                logging.warning(
+                    f"RW_CHANGED t_id={t_id} READS op={op_part} "
+                    f"orig={sorted(original_read_keys)[:8]} "
+                    f"fb={sorted(fallback_read_keys)[:8]} "
+                    f"orig_n={len(original_read_keys)} fb_n={len(fallback_read_keys)} "
+                    f"orig-fb={sorted(original_read_keys - fallback_read_keys)[:5]} "
+                    f"fb-orig={sorted(fallback_read_keys - original_read_keys)[:5]}",
+                )
                 return True
 
-        # Check for fallback reads on operator_partitions not in self.operator_partitions
         for op_part in fallback_reads:
             if op_part not in self.operator_partitions:
-                # Original had no reads here (since it's not a local partition),
-                # but fallback did — sets differ
+                logging.warning(
+                    f"RW_CHANGED t_id={t_id} READS on extra op={op_part} "
+                    f"keys={sorted(fallback_reads[op_part])[:5]}",
+                )
                 return True
 
-        # Compare write sets: original vs fallback
         fallback_writes = self.fallback_commit_buffer.get(t_id, {})
         for op_part in self.operator_partitions:
             original_write_keys = set(self.write_sets[op_part].get(t_id, {}).keys())
             fallback_write_keys = set(fallback_writes.get(op_part, {}).keys())
             if original_write_keys != fallback_write_keys:
+                logging.warning(
+                    f"RW_CHANGED t_id={t_id} WRITES op={op_part} "
+                    f"orig_n={len(original_write_keys)} fb_n={len(fallback_write_keys)} "
+                    f"orig-fb={sorted(original_write_keys - fallback_write_keys)[:5]} "
+                    f"fb-orig={sorted(fallback_write_keys - original_write_keys)[:5]}",
+                )
                 return True
 
-        # Check for fallback writes on operator_partitions not in self.operator_partitions
-        return any(op_part not in self.operator_partitions for op_part in fallback_writes)
+        for op_part in fallback_writes:
+            if op_part not in self.operator_partitions:
+                logging.warning(
+                    f"RW_CHANGED t_id={t_id} WRITES on extra op={op_part}",
+                )
+                return True
+        return False
 
     def cleanup(self) -> None:
         for operator_partition in self.operator_partitions:

--- a/worker/operator_state/aria/base_aria_state.py
+++ b/worker/operator_state/aria/base_aria_state.py
@@ -178,53 +178,45 @@ class BaseAriaState(BaseOperatorState):
 
         Per the Aria paper, if a transaction's rw-set differs from its original
         optimistic execution, the fallback dependency graph is invalid and the
-        transaction must be rescheduled to the next epoch.
-        """
-        from styx.common.logging import logging
+        transaction must be rescheduled.
 
+        Relaxation (read & write side): a diff key K that does not yet exist
+        in committed state (`self.data`) is treated as safe.
+          - Write side: K is a fresh insert. Check-then-commit runs without an
+            `await` so {check, commit} is atomic on the asyncio loop; a sibling
+            inserting K serializes via reschedule.
+          - Read side: the read returned `None` (K didn't exist); whether K
+            was "observed" is immaterial to the txn's outcome. A sibling that
+            actually committed K shows up in `self.data` at check time and
+            forces reschedule.
+        """
         fallback_reads = self.fallback_read_sets.get(t_id, {})
         for op_part in self.operator_partitions:
             original_read_keys = self.read_sets[op_part].get(t_id, set())
             fallback_read_keys = fallback_reads.get(op_part, set())
-            if original_read_keys != fallback_read_keys:
-                logging.warning(
-                    f"RW_CHANGED t_id={t_id} READS op={op_part} "
-                    f"orig={sorted(original_read_keys)[:8]} "
-                    f"fb={sorted(fallback_read_keys)[:8]} "
-                    f"orig_n={len(original_read_keys)} fb_n={len(fallback_read_keys)} "
-                    f"orig-fb={sorted(original_read_keys - fallback_read_keys)[:5]} "
-                    f"fb-orig={sorted(fallback_read_keys - original_read_keys)[:5]}",
-                )
+            if original_read_keys == fallback_read_keys:
+                continue
+            diff_keys = original_read_keys.symmetric_difference(fallback_read_keys)
+            committed = self.data[op_part]
+            if any(k in committed for k in diff_keys):
                 return True
 
         for op_part in fallback_reads:
             if op_part not in self.operator_partitions:
-                logging.warning(
-                    f"RW_CHANGED t_id={t_id} READS on extra op={op_part} "
-                    f"keys={sorted(fallback_reads[op_part])[:5]}",
-                )
                 return True
 
         fallback_writes = self.fallback_commit_buffer.get(t_id, {})
         for op_part in self.operator_partitions:
             original_write_keys = set(self.write_sets[op_part].get(t_id, {}).keys())
             fallback_write_keys = set(fallback_writes.get(op_part, {}).keys())
-            if original_write_keys != fallback_write_keys:
-                logging.warning(
-                    f"RW_CHANGED t_id={t_id} WRITES op={op_part} "
-                    f"orig_n={len(original_write_keys)} fb_n={len(fallback_write_keys)} "
-                    f"orig-fb={sorted(original_write_keys - fallback_write_keys)[:5]} "
-                    f"fb-orig={sorted(fallback_write_keys - original_write_keys)[:5]}",
-                )
+            if original_write_keys == fallback_write_keys:
+                continue
+            diff_keys = original_write_keys.symmetric_difference(fallback_write_keys)
+            committed = self.data[op_part]
+            if any(k in committed for k in diff_keys):
                 return True
 
-        for op_part in fallback_writes:
-            if op_part not in self.operator_partitions:
-                logging.warning(
-                    f"RW_CHANGED t_id={t_id} WRITES on extra op={op_part}",
-                )
-                return True
-        return False
+        return any(op_part not in self.operator_partitions for op_part in fallback_writes)
 
     def cleanup(self) -> None:
         for operator_partition in self.operator_partitions:

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -2,15 +2,15 @@ setuptools==82.0.1
 Cython==3.2.4
 # networking service
 uvloop==0.22.1
-msgspec==0.20.0
+msgspec==0.21.1
 cloudpickle==3.1.2
 cityhash==0.4.10
 zstandard==0.25.0
 # monitoring
 psutil==7.2.2
 # Kafka
-aiokafka==0.13.0
+aiokafka==0.14.0
 # snapshots
-boto3==1.42.68
+boto3==1.43.7
 # deathstar
 geopy

--- a/worker/transactional_protocols/aria.py
+++ b/worker/transactional_protocols/aria.py
@@ -44,7 +44,6 @@ FALLBACK_STRATEGY_PERCENTAGE: float = float(
 )
 SNAPSHOTTING_THREADS: int = int(os.getenv("SNAPSHOTTING_THREADS", "4"))
 SEQUENCE_MAX_SIZE: int = int(os.getenv("SEQUENCE_MAX_SIZE", "1_000"))
-USE_FALLBACK_CACHE: bool = bool(strtobool(os.getenv("USE_FALLBACK_CACHE", "true")))
 KAFKA_URL: str = os.environ["KAFKA_URL"]
 USE_ASYNC_MIGRATION: bool = bool(strtobool(os.getenv("USE_ASYNC_MIGRATION", "true")))
 ASYNC_MIGRATION_BATCH_SIZE: int = int(os.getenv("ASYNC_MIGRATION_BATCH_SIZE", "2_000"))
@@ -153,7 +152,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             MessageType.SyncCleanup: asyncio.Lock(),
             MessageType.AriaProcessingDone: asyncio.Lock(),
             MessageType.Ack: asyncio.Lock(),
-            MessageType.AckCache: asyncio.Lock(),
             MessageType.ChainAbort: asyncio.Lock(),
             MessageType.Unlock: asyncio.Lock(),
             MessageType.DeterministicReordering: asyncio.Lock(),
@@ -185,7 +183,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             MessageType.SyncCleanup: self._handle_sync_cleanup,
             MessageType.AriaProcessingDone: self._handle_aria_processing_done,
             MessageType.Ack: self._handle_ack,
-            MessageType.AckCache: self._handle_ack_cache,
             MessageType.ChainAbort: self._handle_chain_abort,
             MessageType.ResponseToRoot: self._handle_response_to_root,
             MessageType.Unlock: self._handle_unlock,
@@ -246,7 +243,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             payload.partition,
             payload.ack_payload,
             fallback_mode,
-            USE_FALLBACK_CACHE,
             payload.params,
             self,
         )
@@ -323,9 +319,6 @@ class AriaProtocol(BaseTransactionalProtocol):
                 )
                 return
 
-            if USE_FALLBACK_CACHE:
-                self.networking.add_remote_function_call(t_id, payload)
-
             self.background_functions.create_task(self.run_function(t_id, payload))
 
     async def _handle_wrong_partition_request(self, data: bytes) -> None:
@@ -395,19 +388,12 @@ class AriaProtocol(BaseTransactionalProtocol):
     async def _handle_ack(self, data: bytes) -> None:
         mt = MessageType.Ack
         async with self.networking_locks[mt]:
-            ack_id, fraction_str, chain_participants, partial_node_count = self.networking.decode_message(data)
+            ack_id, fraction_str, chain_participants = self.networking.decode_message(data)
             self.networking.add_ack_fraction_str(
                 ack_id,
                 fraction_str,
                 chain_participants,
-                partial_node_count,
             )
-
-    async def _handle_ack_cache(self, data: bytes) -> None:
-        mt = MessageType.AckCache
-        async with self.networking_locks[mt]:
-            (ack_id,) = self.networking.decode_message(data)
-            self.networking.add_ack_cnt(ack_id)
 
     async def _handle_chain_abort(self, data: bytes) -> None:
         mt = MessageType.ChainAbort
@@ -861,7 +847,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         t_id: int,
         payload: RunFuncPayload,
         internal: bool = False,
-        collocated_same_t_id_functions: list[RunFuncPayload] | None = None,  # important when fallback cache is true
     ) -> None:
         # Wait for all transactions that this transaction depends on to finish
         if self.waiting_on_transactions.get(t_id):
@@ -875,15 +860,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         # Run transaction
         success = await self.run_function(t_id, payload, fallback_mode=True)
         if not internal:
-            # if root of chain
-            if collocated_same_t_id_functions is not None:
-                await asyncio.gather(
-                    *[
-                        self.run_function(t_id, c_payload, fallback_mode=True)
-                        for c_payload in collocated_same_t_id_functions
-                    ],
-                )
-
             if t_id in self.networking.waited_ack_events:
                 # wait on ack of parts
                 await self.networking.waited_ack_events[t_id].wait()
@@ -930,36 +906,12 @@ class AriaProtocol(BaseTransactionalProtocol):
         self.networking.clear_aborted_events_for_fallback()
         for sequenced_item in aborted_sequence:
             # current worker is the root of the chain
-            collocated_t_id_functions = None
-            if USE_FALLBACK_CACHE:
-                self.networking.reset_ack_for_fallback_cache(sequenced_item.t_id)
-                if sequenced_item.t_id in self.networking.remote_function_calls:
-                    collocated_t_id_functions = self.networking.remote_function_calls[sequenced_item.t_id]
-                    del self.networking.remote_function_calls[sequenced_item.t_id]
-            else:
-                self.networking.reset_ack_for_fallback(sequenced_item.t_id)
+            self.networking.reset_ack_for_fallback(sequenced_item.t_id)
             fallback_tasks.append(
                 self.run_fallback_function(
                     sequenced_item.t_id,
                     sequenced_item.payload,
-                    collocated_same_t_id_functions=collocated_t_id_functions,
                 ),
-            )
-
-        if USE_FALLBACK_CACHE:
-            remote_payloads = [
-                (t_id, payloads)
-                for t_id, payloads in self.networking.remote_function_calls.items()
-                if t_id in self.t_ids_to_reschedule
-            ]
-            fallback_tasks.extend(
-                self.run_fallback_function(
-                    t_id,
-                    payload,
-                    internal=True,
-                )
-                for t_id, payloads in remote_payloads
-                for payload in payloads
             )
 
         await self.sync_workers(

--- a/worker/transactional_protocols/aria.py
+++ b/worker/transactional_protocols/aria.py
@@ -5,7 +5,6 @@ import time
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING
 
-from msgspec import msgpack
 from setuptools._distutils.util import strtobool
 from styx.common.base_protocol import BaseTransactionalProtocol
 from styx.common.logging import logging
@@ -144,22 +143,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             MessageType.DeterministicReordering: asyncio.Event(),
         }
 
-        self.networking_locks: dict[MessageType, asyncio.Lock] = {
-            MessageType.RunFunRemote: asyncio.Lock(),
-            MessageType.AriaCommit: asyncio.Lock(),
-            MessageType.AriaFallbackDone: asyncio.Lock(),
-            MessageType.AriaFallbackStart: asyncio.Lock(),
-            MessageType.SyncCleanup: asyncio.Lock(),
-            MessageType.AriaProcessingDone: asyncio.Lock(),
-            MessageType.Ack: asyncio.Lock(),
-            MessageType.ChainAbort: asyncio.Lock(),
-            MessageType.Unlock: asyncio.Lock(),
-            MessageType.DeterministicReordering: asyncio.Lock(),
-            MessageType.WrongPartitionRequest: asyncio.Lock(),
-            MessageType.ResponseToRoot: asyncio.Lock(),
-            MessageType.AsyncMigration: asyncio.Lock(),
-        }
-
         self.remote_wants_to_proceed: bool = False
         self.currently_processing: bool = False
 
@@ -211,7 +194,7 @@ class AriaProtocol(BaseTransactionalProtocol):
                 await self.migration_sender_task
         except asyncio.CancelledError:
             logging.warning("Protocol coroutines stopped")
-        logging.warning(f"Active tasks: {asyncio.all_tasks()}")
+        logging.info(f"Active tasks: {asyncio.all_tasks()}")
         self.stopped.set()
         logging.warning(f"Aria protocol stopped at: {self.topic_partition_offsets}")
 
@@ -230,7 +213,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         payload: RunFuncPayload,
         fallback_mode: bool = False,
     ) -> bool:
-        # logging.warning(f"Running function: {payload.function_name} with T_ID {t_id} with params {payload.params}"
+        # logging.info(f"Running function: {payload.function_name} with T_ID {t_id} with params {payload.params}"
         #              f" and ack payload {payload.ack_payload}")
 
         operator_partition = self.registered_operators[(payload.operator_name, payload.partition)]
@@ -288,147 +271,146 @@ class AriaProtocol(BaseTransactionalProtocol):
     # Handlers
     # -------------------
     async def _handle_run_fun_remote(self, data: bytes) -> None:
-        mt = MessageType.RunFunRemote
-        async with self.networking_locks[mt]:
-            logging.warning("CALLED RUN FUN FROM PEER")
-            (
-                t_id,
-                request_id,
-                operator_name,
-                function_name,
-                key,
-                partition,
-                fallback_enabled,
-                params,
-                ack,
-            ) = self.networking.decode_message(data)
+        # Lock-free: no awaits in this handler; single-threaded asyncio gives atomicity.
+        logging.debug("CALLED RUN FUN FROM PEER")
+        (
+            t_id,
+            request_id,
+            operator_name,
+            function_name,
+            key,
+            partition,
+            fallback_enabled,
+            params,
+            ack,
+        ) = self.networking.decode_message(data)
 
-            payload = RunFuncPayload(
-                request_id=request_id,
-                key=key,
-                operator_name=operator_name,
-                partition=partition,
-                function_name=function_name,
-                params=params,
-                ack_payload=ack,
+        payload = RunFuncPayload(
+            request_id=request_id,
+            key=key,
+            operator_name=operator_name,
+            partition=partition,
+            function_name=function_name,
+            params=params,
+            ack_payload=ack,
+        )
+
+        if fallback_enabled:
+            # Bypass the semaphore for fallback chain participants: their
+            # dominant time is `await fallback_locking_event_map[d].wait()`,
+            # and those events fire only when other participants (queued
+            # behind the very same semaphore) get to run. Holding a slot
+            # while sleeping causes a cluster-wide deadlock under load.
+            self.background_functions.create_unbounded_task(
+                self.run_fallback_function(t_id, payload, internal=True),
             )
+            return
 
-            if fallback_enabled:
-                self.background_functions.create_task(
-                    self.run_fallback_function(t_id, payload, internal=True),
-                )
-                return
-
-            self.background_functions.create_task(self.run_function(t_id, payload))
+        self.background_functions.create_task(self.run_function(t_id, payload))
 
     async def _handle_wrong_partition_request(self, data: bytes) -> None:
-        mt = MessageType.WrongPartitionRequest
-        async with self.networking_locks[mt]:
-            (
-                request_id,
-                operator_name,
-                function_name,
-                key,
-                partition,
-                kafka_ingress_partition,
-                kafka_offset,
-                params,
-            ) = self.networking.decode_message(data)
+        # Lock-free: no awaits.
+        (
+            request_id,
+            operator_name,
+            function_name,
+            key,
+            partition,
+            kafka_ingress_partition,
+            kafka_offset,
+            params,
+        ) = self.networking.decode_message(data)
 
-            logging.warning(
-                f"Aria WrongPartitionRequest: {request_id}:{operator_name}:{kafka_ingress_partition}",
-            )
+        logging.debug(
+            f"Aria WrongPartitionRequest: {request_id}:{operator_name}:{kafka_ingress_partition}",
+        )
 
-            payload = RunFuncPayload(
-                request_id=request_id,
-                key=key,
-                operator_name=operator_name,
-                partition=partition,
-                function_name=function_name,
-                params=params,
-                kafka_ingress_partition=kafka_ingress_partition,
-                kafka_offset=kafka_offset,
-            )
-            self.sequencer.sequence(payload)
+        payload = RunFuncPayload(
+            request_id=request_id,
+            key=key,
+            operator_name=operator_name,
+            partition=partition,
+            function_name=function_name,
+            params=params,
+            kafka_ingress_partition=kafka_ingress_partition,
+            kafka_offset=kafka_offset,
+        )
+        self.sequencer.sequence(payload)
 
     async def _handle_deprecated_rqrs(self, _: bytes) -> None:
         logging.error("REQUEST RESPONSE HAS BEEN DEPRECATED")
 
     async def _handle_aria_commit(self, data: bytes) -> None:
+        # Lock-free: no awaits.
         mt = MessageType.AriaCommit
-        async with self.networking_locks[mt]:
-            (
-                self.concurrency_aborts_everywhere,
-                self.total_processed_seq_size,
-                self.max_t_counter,
-                self.snapshot_marker_received,
-            ) = self.networking.decode_message(data)
-            self.sync_workers_event[mt].set()
+        (
+            self.concurrency_aborts_everywhere,
+            self.total_processed_seq_size,
+            self.max_t_counter,
+            self.snapshot_marker_received,
+        ) = self.networking.decode_message(data)
+        self.sync_workers_event[mt].set()
 
     async def _handle_sync_event_only(self, data: bytes) -> None:
-        # Used for AriaFallbackDone / AriaFallbackStart
+        # Used for AriaFallbackDone / AriaFallbackStart. Lock-free: no awaits.
         mt: MessageType = self.networking.get_msg_type(data)
-        async with self.networking_locks[mt]:
-            self.sync_workers_event[mt].set()
+        self.sync_workers_event[mt].set()
 
     async def _handle_sync_cleanup(self, data: bytes) -> None:
+        # Lock-free: no awaits.
         mt = MessageType.SyncCleanup
-        async with self.networking_locks[mt]:
-            (stop_gracefully,) = self.networking.decode_message(data)
-            if stop_gracefully:
-                self.running = False
-            self.sync_workers_event[mt].set()
+        (stop_gracefully,) = self.networking.decode_message(data)
+        if stop_gracefully:
+            self.running = False
+        self.sync_workers_event[mt].set()
 
     async def _handle_aria_processing_done(self, data: bytes) -> None:
+        # Lock-free: no awaits.
         mt = MessageType.AriaProcessingDone
-        async with self.networking_locks[mt]:
-            (self.networking.logic_aborts_everywhere,) = self.networking.decode_message(data)
-            self.sync_workers_event[mt].set()
+        (self.networking.logic_aborts_everywhere,) = self.networking.decode_message(data)
+        self.sync_workers_event[mt].set()
 
     async def _handle_ack(self, data: bytes) -> None:
-        mt = MessageType.Ack
-        async with self.networking_locks[mt]:
-            ack_id, fraction_str, chain_participants = self.networking.decode_message(data)
-            self.networking.add_ack_fraction_str(
-                ack_id,
-                fraction_str,
-                chain_participants,
-            )
+        # Lock-free: no awaits.
+        ack_id, fraction_str, chain_participants = self.networking.decode_message(data)
+        self.networking.add_ack_fraction_str(
+            ack_id,
+            fraction_str,
+            chain_participants,
+        )
 
     async def _handle_chain_abort(self, data: bytes) -> None:
-        mt = MessageType.ChainAbort
-        async with self.networking_locks[mt]:
-            ack_id, exception_str = self.networking.decode_message(data)
-            self.networking.abort_chain(ack_id, exception_str)
+        # Lock-free: no awaits.
+        ack_id, exception_str = self.networking.decode_message(data)
+        self.networking.abort_chain(ack_id, exception_str)
 
     async def _handle_response_to_root(self, data: bytes) -> None:
-        mt = MessageType.ResponseToRoot
-        async with self.networking_locks[mt]:
-            ack_id, resp = self.networking.decode_message(data)
-            self.networking.add_response(ack_id, resp)
+        # Lock-free: no awaits.
+        ack_id, resp = self.networking.decode_message(data)
+        self.networking.add_response(ack_id, resp)
 
     async def _handle_unlock(self, data: bytes) -> None:
-        mt = MessageType.Unlock
-        async with self.networking_locks[mt]:
-            # fallback phase
-            # here we handle the logic to unlock locks held by the provided distributed transaction
-            t_id, success = self.networking.decode_message(data)
-            if success:
-                # commit changes
-                self.local_state.commit_fallback_transaction(t_id)
-            # unlock
-            await self.unlock_tid(t_id)
+        # fallback phase
+        # here we handle the logic to unlock locks held by the provided distributed transaction
+        # The outer lock is unnecessary: commit_fallback_transaction is sync, and
+        # unlock_tid acquires its own fallback_locking_event_map_lock around the await.
+        t_id, success = self.networking.decode_message(data)
+        if success:
+            # commit changes
+            self.local_state.commit_fallback_transaction(t_id)
+        # unlock
+        await self.unlock_tid(t_id)
 
     async def _handle_deterministic_reordering(self, data: bytes) -> None:
+        # Lock-free: no awaits.
         mt = MessageType.DeterministicReordering
-        async with self.networking_locks[mt]:
-            _, global_read_reservations, global_write_set, global_read_set = self.networking.decode_message(data)
-            self.local_state.set_global_read_write_sets(
-                global_read_reservations,
-                global_write_set,
-                global_read_set,
-            )
-            self.sync_workers_event[mt].set()
+        _, global_read_reservations, global_write_set, global_read_set = self.networking.decode_message(data)
+        self.local_state.set_global_read_write_sets(
+            global_read_reservations,
+            global_write_set,
+            global_read_set,
+        )
+        self.sync_workers_event[mt].set()
 
     async def _handle_remote_wants_to_proceed(self, _: bytes) -> None:
         if not self.currently_processing:
@@ -436,18 +418,17 @@ class AriaProtocol(BaseTransactionalProtocol):
             self.ingress.messages_available.set()
 
     async def _handle_async_migration(self, data: bytes) -> None:
-        mt = MessageType.AsyncMigration
+        # Lock-free: no awaits.
         operator_partition, batch = self.networking.decode_message(data)
-        logging.warning(f"MIGRATION | Received migration batch for: {operator_partition}")
+        logging.debug(f"MIGRATION | Received migration batch for: {operator_partition}")
 
-        async with self.networking_locks[mt]:
-            self.local_state.set_batch_data_from_migration(operator_partition, batch)
-            # Unblock any transactions waiting for these keys via RequestRemoteKey
-            op = tuple(operator_partition)
-            if op in self.networking.wait_remote_key_event:
-                for key in batch:
-                    if key in self.networking.wait_remote_key_event.get(op, {}):
-                        self.networking.wait_remote_key_event[op][key].set()
+        self.local_state.set_batch_data_from_migration(operator_partition, batch)
+        # Unblock any transactions waiting for these keys via RequestRemoteKey
+        op = tuple(operator_partition)
+        if op in self.networking.wait_remote_key_event:
+            for key in batch:
+                if key in self.networking.wait_remote_key_event.get(op, {}):
+                    self.networking.wait_remote_key_event[op][key].set()
 
     async def _write_to_wal(self, sequence: list[SequencedItem]) -> tuple[float, float]:
         start_wal = timer()
@@ -460,7 +441,7 @@ class AriaProtocol(BaseTransactionalProtocol):
             topic="sequencer-wal",
         )
         end_wal = timer()
-        logging.warning(
+        logging.debug(
             f"Write to WAL successful at epoch: {self.sequencer.epoch_counter}",
         )
         return start_wal, end_wal
@@ -475,11 +456,10 @@ class AriaProtocol(BaseTransactionalProtocol):
             operator_name, partition = operator_partition
             worker = self.dns[operator_name][partition]
             if worker == self.id:
-                async with self.networking_locks[MessageType.AsyncMigration]:
-                    self.local_state.set_batch_data_from_migration(
-                        operator_partition,
-                        k_v_pairs,
-                    )
+                self.local_state.set_batch_data_from_migration(
+                    operator_partition,
+                    k_v_pairs,
+                )
             else:
                 send_tasks.append(
                     self.networking.send_message(
@@ -559,8 +539,6 @@ class AriaProtocol(BaseTransactionalProtocol):
 
     async def _process_epoch(self, sequence: list[SequencedItem]) -> None:
         epoch_start = timer()
-        ec = self.sequencer.epoch_counter
-        logging.warning(f"{self.id} ||| EPOCH {ec} BEGIN (seq={len(sequence)})")
 
         timings = await self._run_epoch_functions_and_chain(sequence)
 
@@ -568,20 +546,19 @@ class AriaProtocol(BaseTransactionalProtocol):
         sync_time += await self._sync_processing_done()
 
         conflict_resolution_start = timer()
+        # HERE WE KNOW ALL THE LOGIC ABORTS
         self.local_state.remove_aborted_from_rw_sets(
             self.networking.logic_aborts_everywhere,
         )
         concurrency_aborts = await self._compute_concurrency_aborts()
         conflict_resolution_end = timer()
-        logging.warning(
-            f"{self.id} ||| EPOCH {ec} concurrency_aborts={len(concurrency_aborts)} "
-            f"logic_aborts={len(self.networking.logic_aborts_everywhere)}",
-        )
 
         local_abort_rate = (len(concurrency_aborts) / len(sequence)) if sequence else 0.0
 
+        # Notify peers that we are ready to commit
         sync_time += await self._sync_commit(sequence, concurrency_aborts)
 
+        # HERE WE KNOW ALL THE CONCURRENCY ABORTS
         commit_start = timer()
         self._commit_and_prepare_responses(sequence)
         await self.send_delta_to_snapshotting_proc()
@@ -590,20 +567,16 @@ class AriaProtocol(BaseTransactionalProtocol):
         fallback_start = timer()
         abort_rate = await self._maybe_run_fallback()
         fallback_end = timer()
-        logging.warning(f"{self.id} ||| EPOCH {ec} fallback_ms={(fallback_end - fallback_start) * 1000:.1f}")
 
         self._advance_offsets(sequence)
 
         self.sequencer.increment_epoch(self.max_t_counter, self.t_ids_to_reschedule)
-        logging.warning(f"{self.id} ||| EPOCH {ec} waiting on responses to be sent")
         await self.wait_responses_to_be_sent.wait()
-        logging.warning(f"{self.id} ||| EPOCH {ec} responses sent, cleaning up")
         self.cleanup_after_epoch()
 
         snap_start = timer()
         await self.take_snapshot()
         snap_end = timer()
-        logging.warning(f"{self.id} ||| EPOCH {ec} END")
 
         epoch_end = timer()
 
@@ -628,8 +601,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         if not sequence:
             return {"wal_ms": 0.0, "func_ms": 0.0, "chain_ms": 0.0}
 
-        logging.warning(f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | running {len(sequence)} txns")
-
         start_wal, end_wal = await self._write_to_wal(sequence)
 
         start_func = timer()
@@ -637,10 +608,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             *[self.run_function(item.t_id, item.payload) for item in sequence],
         )
         end_func = timer()
-        logging.warning(
-            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | functions done, "
-            f"{len(self.networking.waited_ack_events)} chains pending ack",
-        )
 
         # Wait for chains to finish
         start_chain = timer()
@@ -648,10 +615,6 @@ class AriaProtocol(BaseTransactionalProtocol):
             *[ack.wait() for ack in self.networking.waited_ack_events.values()],
         )
         end_chain = timer()
-        logging.warning(
-            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | chain acks settled in "
-            f"{(end_chain - start_chain) * 1000:.1f}ms",
-        )
 
         return {
             "wal_ms": (end_wal - start_wal) * 1000,
@@ -668,13 +631,13 @@ class AriaProtocol(BaseTransactionalProtocol):
         )
         end = timer()
 
-        logging.warning(
+        logging.debug(
             f"{self.id} ||| logic_aborts_everywhere: {self.networking.logic_aborts_everywhere}",
         )
         return end - start
 
     async def _compute_concurrency_aborts(self) -> set[int]:
-        logging.warning(f"{self.id} ||| Checking conflicts...")
+        logging.debug(f"{self.id} ||| Checking conflicts...")
 
         handlers = {
             AriaConflictDetectionType.DEFAULT_SERIALIZABLE: self._conflicts_default,
@@ -731,7 +694,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         return end - start
 
     def _commit_and_prepare_responses(self, sequence: list[SequencedItem]) -> None:
-        logging.warning(
+        logging.debug(
             f"{self.id} ||| Starting commit! {self.concurrency_aborts_everywhere}",
         )
 
@@ -743,15 +706,19 @@ class AriaProtocol(BaseTransactionalProtocol):
             item for item in sequence if item.t_id not in self.concurrency_aborts_everywhere
         ]
 
+        # Shallow copies — values (response bytes / exception strings) are
+        # immutable, and cleanup_after_epoch will rebind the originals rather
+        # than mutating these dicts. Cheaper than the msgpack round-trip we
+        # used to do here.
         self.aio_task_scheduler.create_task(
             self.send_responses(
                 current_completed_t_ids,
-                msgpack.decode(msgpack.encode(self.networking.client_responses)),
-                msgpack.decode(msgpack.encode(self.networking.aborted_events)),
+                dict(self.networking.client_responses),
+                dict(self.networking.aborted_events),
             ),
         )
 
-        logging.warning(
+        logging.debug(
             f"{self.id} ||| Sequence committed! | "
             f"{len(self.concurrency_aborts_everywhere)} / {self.total_processed_seq_size}",
         )
@@ -763,7 +730,7 @@ class AriaProtocol(BaseTransactionalProtocol):
             else 0.0
         )
         if abort_rate > FALLBACK_STRATEGY_PERCENTAGE:
-            logging.warning(
+            logging.debug(
                 f"{self.id} ||| Epoch: {self.sequencer.epoch_counter} "
                 f"Abort percentage: {int(abort_rate * 100)}% initiating fallback strategy...",
             )
@@ -808,7 +775,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         epoch_latency = max(round((epoch_end - epoch_start) * 1000, 4), 1)
         epoch_throughput = ((len(sequence) - len(self.concurrency_aborts_everywhere)) * 1000) // epoch_latency  # TPS
 
-        logging.warning(
+        logging.debug(
             f"{self.id} ||| Epoch: {self.sequencer.epoch_counter - 1} done in "
             f"{epoch_latency}ms "
             f"global logic aborts: {len(self.networking.logic_aborts_everywhere)} "
@@ -865,84 +832,77 @@ class AriaProtocol(BaseTransactionalProtocol):
         payload: RunFuncPayload,
         internal: bool = False,
     ) -> None:
-        logging.warning(
-            f"{self.id} ||| FB enter t_id={t_id} internal={internal} fn={payload.function_name}",
-        )
         # Wait for all transactions that this transaction depends on to finish
         if self.waiting_on_transactions.get(t_id):
-            deps = [
-                d for d in self.waiting_on_transactions[t_id]
-                if d in self.fallback_locking_event_map
+            tasks = [
+                self.fallback_locking_event_map[dependency_t_id].wait()
+                for dependency_t_id in self.waiting_on_transactions[t_id]
+                if dependency_t_id in self.fallback_locking_event_map
             ]
-            if deps:
-                logging.warning(f"{self.id} ||| FB t_id={t_id} waiting on deps {deps}")
-            tasks = [self.fallback_locking_event_map[d].wait() for d in deps]
             await asyncio.gather(*tasks)
-            if deps:
-                logging.warning(f"{self.id} ||| FB t_id={t_id} deps released")
 
         # Run transaction
         success = await self.run_function(t_id, payload, fallback_mode=True)
         if not internal:
             if t_id in self.networking.waited_ack_events:
-                logging.warning(f"{self.id} ||| FB root t_id={t_id} awaiting chain ack")
+                # wait on ack of parts
                 await self.networking.waited_ack_events[t_id].wait()
-                logging.warning(f"{self.id} ||| FB root t_id={t_id} chain ack received")
             transaction_failed: bool = t_id in self.networking.aborted_events or not success
 
+            # Per the Aria paper: if the rw-set changed during fallback
+            # re-execution, the dependency graph is invalid — reschedule
+            # the transaction to the next epoch instead of committing.
             rw_changed = self.local_state.has_fallback_rw_set_changed(t_id)
             if not transaction_failed and not rw_changed:
                 self.local_state.commit_fallback_transaction(t_id)
             elif rw_changed:
                 self.fallback_rescheduled_t_ids.add(t_id)
                 transaction_failed = True
-            logging.warning(
-                f"{self.id} ||| FB root t_id={t_id} commit_path "
-                f"failed={transaction_failed} rw_changed={rw_changed}",
-            )
 
             await self.fallback_unlock(t_id, success=not transaction_failed)
 
-            if t_id in self.networking.aborted_events:
-                await self.egress.send_immediate(
+            # If the txn was rescheduled because the fallback rw-set drifted
+            # from the optimistic one, the commit hasn't happened and the
+            # response isn't durable yet. Defer egress to the next epoch's
+            # run; otherwise we'd send the response now AND again when the
+            # txn finally commits, producing duplicates.
+            # Batched send: each `egress.send` enqueues a Kafka future and
+            # returns immediately; the strategy flushes all of them with a
+            # single `send_batch()` at the end of fallback. Previously we
+            # used `send_immediate` here, which did a synchronous round-trip
+            # per txn — fine with 1-2 fallback commits per epoch, but a major
+            # bottleneck when fallback commits ~100 txns at once.
+            if rw_changed:
+                pass
+            elif t_id in self.networking.aborted_events:
+                await self.egress.send(
                     key=payload.request_id,
                     value=msgpack_serialization(self.networking.aborted_events[t_id]),
                     operator_name=payload.operator_name,
                     partition=payload.partition,
                 )
             elif t_id in self.networking.client_responses:
-                await self.egress.send_immediate(
+                await self.egress.send(
                     key=payload.request_id,
                     value=msgpack_serialization(self.networking.client_responses[t_id]),
                     operator_name=payload.operator_name,
                     partition=payload.partition,
                 )
-        logging.warning(f"{self.id} ||| FB exit t_id={t_id} internal={internal}")
 
     async def run_fallback_strategy(self) -> None:
-        logging.warning(
-            f"{self.id} ||| FB STRATEGY start epoch={self.sequencer.epoch_counter} "
-            f"reschedule={sorted(self.t_ids_to_reschedule)}",
-        )
+        logging.debug("Starting fallback strategy...")
 
         (self.waiting_on_transactions, self.fallback_locking_event_map) = self.local_state.get_dep_transactions(
             self.t_ids_to_reschedule
-        )
-        logging.warning(
-            f"{self.id} ||| FB deps={dict(self.waiting_on_transactions)} "
-            f"locks_for={sorted(self.fallback_locking_event_map.keys())}",
         )
 
         fallback_tasks = []
         aborted_sequence: list[SequencedItem] = self.sequencer.get_aborted_sequence(
             self.t_ids_to_reschedule,
         )
-        logging.warning(
-            f"{self.id} ||| FB aborted_sequence size={len(aborted_sequence)} "
-            f"t_ids={[s.t_id for s in aborted_sequence]}",
-        )
         self.networking.clear_aborted_events_for_fallback()
         for sequenced_item in aborted_sequence:
+            # current worker is the root of the chain
             self.networking.reset_ack_for_fallback(sequenced_item.t_id)
             fallback_tasks.append(
                 self.run_fallback_function(
@@ -957,11 +917,14 @@ class AriaProtocol(BaseTransactionalProtocol):
             serializer=Serializer.MSGPACK,
         )
         if fallback_tasks:
-            logging.warning(f"{self.id} ||| FB gather {len(fallback_tasks)} root tasks")
             await asyncio.gather(*fallback_tasks)
+            # Flush all fallback egress sends in one batch (each root above
+            # used `egress.send`, which enqueues; `send_batch` awaits the
+            # producer futures together).
+            await self.egress.send_batch()
 
-        logging.warning(
-            f"{self.id} ||| FB STRATEGY local-done epoch={self.sequencer.epoch_counter}, waiting for peers",
+        logging.debug(
+            f"Epoch: {self.sequencer.epoch_counter} Fallback strategy done waiting for peers",
         )
 
         await self.sync_workers(
@@ -1030,9 +993,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         message: tuple | bytes,
         serializer: Serializer = Serializer.MSGPACK,
     ) -> None:
-        logging.warning(
-            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | sync_workers -> {msg_type.name} (sending)",
-        )
         await self.networking.send_message(
             DISCOVERY_HOST,
             DISCOVERY_PORT + 1,
@@ -1042,6 +1002,3 @@ class AriaProtocol(BaseTransactionalProtocol):
         )
         await self.sync_workers_event[msg_type].wait()
         self.sync_workers_event[msg_type].clear()
-        logging.warning(
-            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | sync_workers -> {msg_type.name} (released)",
-        )

--- a/worker/transactional_protocols/aria.py
+++ b/worker/transactional_protocols/aria.py
@@ -211,7 +211,7 @@ class AriaProtocol(BaseTransactionalProtocol):
                 await self.migration_sender_task
         except asyncio.CancelledError:
             logging.warning("Protocol coroutines stopped")
-        logging.info(f"Active tasks: {asyncio.all_tasks()}")
+        logging.warning(f"Active tasks: {asyncio.all_tasks()}")
         self.stopped.set()
         logging.warning(f"Aria protocol stopped at: {self.topic_partition_offsets}")
 
@@ -230,7 +230,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         payload: RunFuncPayload,
         fallback_mode: bool = False,
     ) -> bool:
-        # logging.info(f"Running function: {payload.function_name} with T_ID {t_id} with params {payload.params}"
+        # logging.warning(f"Running function: {payload.function_name} with T_ID {t_id} with params {payload.params}"
         #              f" and ack payload {payload.ack_payload}")
 
         operator_partition = self.registered_operators[(payload.operator_name, payload.partition)]
@@ -290,7 +290,7 @@ class AriaProtocol(BaseTransactionalProtocol):
     async def _handle_run_fun_remote(self, data: bytes) -> None:
         mt = MessageType.RunFunRemote
         async with self.networking_locks[mt]:
-            logging.debug("CALLED RUN FUN FROM PEER")
+            logging.warning("CALLED RUN FUN FROM PEER")
             (
                 t_id,
                 request_id,
@@ -335,7 +335,7 @@ class AriaProtocol(BaseTransactionalProtocol):
                 params,
             ) = self.networking.decode_message(data)
 
-            logging.debug(
+            logging.warning(
                 f"Aria WrongPartitionRequest: {request_id}:{operator_name}:{kafka_ingress_partition}",
             )
 
@@ -438,7 +438,7 @@ class AriaProtocol(BaseTransactionalProtocol):
     async def _handle_async_migration(self, data: bytes) -> None:
         mt = MessageType.AsyncMigration
         operator_partition, batch = self.networking.decode_message(data)
-        logging.debug(f"MIGRATION | Received migration batch for: {operator_partition}")
+        logging.warning(f"MIGRATION | Received migration batch for: {operator_partition}")
 
         async with self.networking_locks[mt]:
             self.local_state.set_batch_data_from_migration(operator_partition, batch)
@@ -460,7 +460,7 @@ class AriaProtocol(BaseTransactionalProtocol):
             topic="sequencer-wal",
         )
         end_wal = timer()
-        logging.debug(
+        logging.warning(
             f"Write to WAL successful at epoch: {self.sequencer.epoch_counter}",
         )
         return start_wal, end_wal
@@ -559,6 +559,8 @@ class AriaProtocol(BaseTransactionalProtocol):
 
     async def _process_epoch(self, sequence: list[SequencedItem]) -> None:
         epoch_start = timer()
+        ec = self.sequencer.epoch_counter
+        logging.warning(f"{self.id} ||| EPOCH {ec} BEGIN (seq={len(sequence)})")
 
         timings = await self._run_epoch_functions_and_chain(sequence)
 
@@ -566,19 +568,20 @@ class AriaProtocol(BaseTransactionalProtocol):
         sync_time += await self._sync_processing_done()
 
         conflict_resolution_start = timer()
-        # HERE WE KNOW ALL THE LOGIC ABORTS
         self.local_state.remove_aborted_from_rw_sets(
             self.networking.logic_aborts_everywhere,
         )
         concurrency_aborts = await self._compute_concurrency_aborts()
         conflict_resolution_end = timer()
+        logging.warning(
+            f"{self.id} ||| EPOCH {ec} concurrency_aborts={len(concurrency_aborts)} "
+            f"logic_aborts={len(self.networking.logic_aborts_everywhere)}",
+        )
 
         local_abort_rate = (len(concurrency_aborts) / len(sequence)) if sequence else 0.0
 
-        # Notify peers that we are ready to commit
         sync_time += await self._sync_commit(sequence, concurrency_aborts)
 
-        # HERE WE KNOW ALL THE CONCURRENCY ABORTS
         commit_start = timer()
         self._commit_and_prepare_responses(sequence)
         await self.send_delta_to_snapshotting_proc()
@@ -587,16 +590,20 @@ class AriaProtocol(BaseTransactionalProtocol):
         fallback_start = timer()
         abort_rate = await self._maybe_run_fallback()
         fallback_end = timer()
+        logging.warning(f"{self.id} ||| EPOCH {ec} fallback_ms={(fallback_end - fallback_start) * 1000:.1f}")
 
         self._advance_offsets(sequence)
 
         self.sequencer.increment_epoch(self.max_t_counter, self.t_ids_to_reschedule)
+        logging.warning(f"{self.id} ||| EPOCH {ec} waiting on responses to be sent")
         await self.wait_responses_to_be_sent.wait()
+        logging.warning(f"{self.id} ||| EPOCH {ec} responses sent, cleaning up")
         self.cleanup_after_epoch()
 
         snap_start = timer()
         await self.take_snapshot()
         snap_end = timer()
+        logging.warning(f"{self.id} ||| EPOCH {ec} END")
 
         epoch_end = timer()
 
@@ -621,6 +628,8 @@ class AriaProtocol(BaseTransactionalProtocol):
         if not sequence:
             return {"wal_ms": 0.0, "func_ms": 0.0, "chain_ms": 0.0}
 
+        logging.warning(f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | running {len(sequence)} txns")
+
         start_wal, end_wal = await self._write_to_wal(sequence)
 
         start_func = timer()
@@ -628,6 +637,10 @@ class AriaProtocol(BaseTransactionalProtocol):
             *[self.run_function(item.t_id, item.payload) for item in sequence],
         )
         end_func = timer()
+        logging.warning(
+            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | functions done, "
+            f"{len(self.networking.waited_ack_events)} chains pending ack",
+        )
 
         # Wait for chains to finish
         start_chain = timer()
@@ -635,6 +648,10 @@ class AriaProtocol(BaseTransactionalProtocol):
             *[ack.wait() for ack in self.networking.waited_ack_events.values()],
         )
         end_chain = timer()
+        logging.warning(
+            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | chain acks settled in "
+            f"{(end_chain - start_chain) * 1000:.1f}ms",
+        )
 
         return {
             "wal_ms": (end_wal - start_wal) * 1000,
@@ -651,13 +668,13 @@ class AriaProtocol(BaseTransactionalProtocol):
         )
         end = timer()
 
-        logging.debug(
+        logging.warning(
             f"{self.id} ||| logic_aborts_everywhere: {self.networking.logic_aborts_everywhere}",
         )
         return end - start
 
     async def _compute_concurrency_aborts(self) -> set[int]:
-        logging.debug(f"{self.id} ||| Checking conflicts...")
+        logging.warning(f"{self.id} ||| Checking conflicts...")
 
         handlers = {
             AriaConflictDetectionType.DEFAULT_SERIALIZABLE: self._conflicts_default,
@@ -714,7 +731,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         return end - start
 
     def _commit_and_prepare_responses(self, sequence: list[SequencedItem]) -> None:
-        logging.debug(
+        logging.warning(
             f"{self.id} ||| Starting commit! {self.concurrency_aborts_everywhere}",
         )
 
@@ -734,7 +751,7 @@ class AriaProtocol(BaseTransactionalProtocol):
             ),
         )
 
-        logging.debug(
+        logging.warning(
             f"{self.id} ||| Sequence committed! | "
             f"{len(self.concurrency_aborts_everywhere)} / {self.total_processed_seq_size}",
         )
@@ -746,7 +763,7 @@ class AriaProtocol(BaseTransactionalProtocol):
             else 0.0
         )
         if abort_rate > FALLBACK_STRATEGY_PERCENTAGE:
-            logging.debug(
+            logging.warning(
                 f"{self.id} ||| Epoch: {self.sequencer.epoch_counter} "
                 f"Abort percentage: {int(abort_rate * 100)}% initiating fallback strategy...",
             )
@@ -791,7 +808,7 @@ class AriaProtocol(BaseTransactionalProtocol):
         epoch_latency = max(round((epoch_end - epoch_start) * 1000, 4), 1)
         epoch_throughput = ((len(sequence) - len(self.concurrency_aborts_everywhere)) * 1000) // epoch_latency  # TPS
 
-        logging.debug(
+        logging.warning(
             f"{self.id} ||| Epoch: {self.sequencer.epoch_counter - 1} done in "
             f"{epoch_latency}ms "
             f"global logic aborts: {len(self.networking.logic_aborts_everywhere)} "
@@ -848,32 +865,41 @@ class AriaProtocol(BaseTransactionalProtocol):
         payload: RunFuncPayload,
         internal: bool = False,
     ) -> None:
+        logging.warning(
+            f"{self.id} ||| FB enter t_id={t_id} internal={internal} fn={payload.function_name}",
+        )
         # Wait for all transactions that this transaction depends on to finish
         if self.waiting_on_transactions.get(t_id):
-            tasks = [
-                self.fallback_locking_event_map[dependency_t_id].wait()
-                for dependency_t_id in self.waiting_on_transactions[t_id]
-                if dependency_t_id in self.fallback_locking_event_map
+            deps = [
+                d for d in self.waiting_on_transactions[t_id]
+                if d in self.fallback_locking_event_map
             ]
+            if deps:
+                logging.warning(f"{self.id} ||| FB t_id={t_id} waiting on deps {deps}")
+            tasks = [self.fallback_locking_event_map[d].wait() for d in deps]
             await asyncio.gather(*tasks)
+            if deps:
+                logging.warning(f"{self.id} ||| FB t_id={t_id} deps released")
 
         # Run transaction
         success = await self.run_function(t_id, payload, fallback_mode=True)
         if not internal:
             if t_id in self.networking.waited_ack_events:
-                # wait on ack of parts
+                logging.warning(f"{self.id} ||| FB root t_id={t_id} awaiting chain ack")
                 await self.networking.waited_ack_events[t_id].wait()
+                logging.warning(f"{self.id} ||| FB root t_id={t_id} chain ack received")
             transaction_failed: bool = t_id in self.networking.aborted_events or not success
 
-            # Per the Aria paper: if the rw-set changed during fallback
-            # re-execution, the dependency graph is invalid — reschedule
-            # the transaction to the next epoch instead of committing.
             rw_changed = self.local_state.has_fallback_rw_set_changed(t_id)
             if not transaction_failed and not rw_changed:
                 self.local_state.commit_fallback_transaction(t_id)
             elif rw_changed:
                 self.fallback_rescheduled_t_ids.add(t_id)
                 transaction_failed = True
+            logging.warning(
+                f"{self.id} ||| FB root t_id={t_id} commit_path "
+                f"failed={transaction_failed} rw_changed={rw_changed}",
+            )
 
             await self.fallback_unlock(t_id, success=not transaction_failed)
 
@@ -891,21 +917,32 @@ class AriaProtocol(BaseTransactionalProtocol):
                     operator_name=payload.operator_name,
                     partition=payload.partition,
                 )
+        logging.warning(f"{self.id} ||| FB exit t_id={t_id} internal={internal}")
 
     async def run_fallback_strategy(self) -> None:
-        logging.debug("Starting fallback strategy...")
+        logging.warning(
+            f"{self.id} ||| FB STRATEGY start epoch={self.sequencer.epoch_counter} "
+            f"reschedule={sorted(self.t_ids_to_reschedule)}",
+        )
 
         (self.waiting_on_transactions, self.fallback_locking_event_map) = self.local_state.get_dep_transactions(
             self.t_ids_to_reschedule
+        )
+        logging.warning(
+            f"{self.id} ||| FB deps={dict(self.waiting_on_transactions)} "
+            f"locks_for={sorted(self.fallback_locking_event_map.keys())}",
         )
 
         fallback_tasks = []
         aborted_sequence: list[SequencedItem] = self.sequencer.get_aborted_sequence(
             self.t_ids_to_reschedule,
         )
+        logging.warning(
+            f"{self.id} ||| FB aborted_sequence size={len(aborted_sequence)} "
+            f"t_ids={[s.t_id for s in aborted_sequence]}",
+        )
         self.networking.clear_aborted_events_for_fallback()
         for sequenced_item in aborted_sequence:
-            # current worker is the root of the chain
             self.networking.reset_ack_for_fallback(sequenced_item.t_id)
             fallback_tasks.append(
                 self.run_fallback_function(
@@ -920,10 +957,11 @@ class AriaProtocol(BaseTransactionalProtocol):
             serializer=Serializer.MSGPACK,
         )
         if fallback_tasks:
+            logging.warning(f"{self.id} ||| FB gather {len(fallback_tasks)} root tasks")
             await asyncio.gather(*fallback_tasks)
 
-        logging.debug(
-            f"Epoch: {self.sequencer.epoch_counter} Fallback strategy done waiting for peers",
+        logging.warning(
+            f"{self.id} ||| FB STRATEGY local-done epoch={self.sequencer.epoch_counter}, waiting for peers",
         )
 
         await self.sync_workers(
@@ -992,6 +1030,9 @@ class AriaProtocol(BaseTransactionalProtocol):
         message: tuple | bytes,
         serializer: Serializer = Serializer.MSGPACK,
     ) -> None:
+        logging.warning(
+            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | sync_workers -> {msg_type.name} (sending)",
+        )
         await self.networking.send_message(
             DISCOVERY_HOST,
             DISCOVERY_PORT + 1,
@@ -1001,3 +1042,6 @@ class AriaProtocol(BaseTransactionalProtocol):
         )
         await self.sync_workers_event[msg_type].wait()
         self.sync_workers_event[msg_type].clear()
+        logging.warning(
+            f"{self.id} ||| EPOCH {self.sequencer.epoch_counter} | sync_workers -> {msg_type.name} (released)",
+        )

--- a/worker/worker.dockerfile
+++ b/worker/worker.dockerfile
@@ -40,12 +40,10 @@ ARG epoch_size=100
 ARG worker_threads=1
 ARG enable_compression=true
 ARG use_composite_keys=true
-ARG use_fallback_cache=true
 
 ENV SEQUENCE_MAX_SIZE=$epoch_size \
     WORKER_THREADS=$worker_threads \
     ENABLE_COMPRESSION=$enable_compression \
-    USE_COMPOSITE_KEYS=$use_composite_keys \
-    USE_FALLBACK_CACHE=$use_fallback_cache
+    USE_COMPOSITE_KEYS=$use_composite_keys
 
 CMD ["/usr/local/bin/start-worker.sh"]

--- a/worker/worker.dockerfile
+++ b/worker/worker.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.3-slim-trixie
+FROM python:3.14.5-slim-trixie
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/worker/worker_service.py
+++ b/worker/worker_service.py
@@ -160,12 +160,6 @@ class Worker:
         self._pending_migration_data: bytes | None = None
         self.migration_error: BaseException | None = None
 
-        self.networking_locks: dict[MessageType, asyncio.Lock] = {
-            MessageType.ReceiveMigrationHashes: asyncio.Lock(),
-            MessageType.ReceiveRemoteKey: asyncio.Lock(),
-            MessageType.RequestRemoteKey: asyncio.Lock(),
-        }
-
         # Bounded queues for backpressure
         # - protocol_queue: for protocol TCP messages
         # - control_queue: for control-plane / worker_controller messages
@@ -557,46 +551,50 @@ class Worker:
         data: bytes,
         msg_type: MessageType,
     ) -> None:
+        # Lock-free: add_remote_keys is sync; single-threaded asyncio gives atomicity.
+        del msg_type
         n_op, payload = self.networking.decode_message(data)
-        async with self.networking_locks[msg_type]:
-            self.local_state.add_remote_keys(n_op, payload)
+        self.local_state.add_remote_keys(n_op, payload)
 
     async def _handle_request_remote_key(
         self,
         data: bytes,
         msg_type: MessageType,
     ) -> None:
+        # Lock-free: pop() is atomic in CPython; concurrent requests for the same
+        # key are race-safe (loser gets None, which the requester handles).
+        del msg_type
         operator_partition, key, old_partition, host, port = self.networking.decode_message(data)
-        async with self.networking_locks[msg_type]:
-            value = self.local_state.get_key_to_migrate(
-                operator_partition,
-                key,
-                old_partition,
-            )
-            await self.networking.send_message(
-                host,
-                port,
-                msg=(operator_partition, key, value),
-                msg_type=MessageType.ReceiveRemoteKey,
-                serializer=Serializer.MSGPACK,
-            )
+        value = self.local_state.get_key_to_migrate(
+            operator_partition,
+            key,
+            old_partition,
+        )
+        await self.networking.send_message(
+            host,
+            port,
+            msg=(operator_partition, key, value),
+            msg_type=MessageType.ReceiveRemoteKey,
+            serializer=Serializer.MSGPACK,
+        )
 
     async def _handle_receive_remote_key(
         self,
         data: bytes,
         msg_type: MessageType,
     ) -> None:
+        # Lock-free: no awaits.
+        del msg_type
         operator_partition, key, value = self.networking.decode_message(data)
-        async with self.networking_locks[msg_type]:
-            self.local_state.set_data_from_migration(operator_partition, key, value)
-            # Guard: the event may have been already signaled by the async
-            # migration handler, or may not exist if no transaction requested it.
-            op = tuple(operator_partition)
-            if (
-                op in self.protocol_networking.wait_remote_key_event
-                and key in self.protocol_networking.wait_remote_key_event[op]
-            ):
-                self.protocol_networking.key_received(op, key)
+        self.local_state.set_data_from_migration(operator_partition, key, value)
+        # Guard: the event may have been already signaled by the async
+        # migration handler, or may not exist if no transaction requested it.
+        op = tuple(operator_partition)
+        if (
+            op in self.protocol_networking.wait_remote_key_event
+            and key in self.protocol_networking.wait_remote_key_event[op]
+        ):
+            self.protocol_networking.key_received(op, key)
 
     async def _handle_migration_repartitioning_done(
         self,
@@ -864,7 +862,13 @@ class Worker:
         while True:
             message: bytes = await self.control_queue.get()
             try:
-                self.aio_task_scheduler.create_task(self.worker_controller(message))
+                # Unbounded: control-plane handlers can suspend on cross-handler
+                # events (e.g. `_handle_migration_repartitioning_done` awaits
+                # `migration_completed` set by `_handle_migration_done`). A
+                # bounded scheduler would let suspended handlers hog slots and
+                # starve the setter. Control volume is low so no backpressure
+                # cost.
+                self.aio_task_scheduler.create_unbounded_task(self.worker_controller(message))
             except Exception as e:
                 logging.error(f"Error while processing control-plane message: {e}")
             finally:


### PR DESCRIPTION
## Summary

Started as a cleanup to drop the fallback result cache, then expanded into a series of correctness and performance fixes uncovered by TPC-C 1-warehouse runs.

### Correctness
- **Remove the fallback cache** to simplify the codebase (`fe2dd4e`).
- **Fix fallback deadlock on local chain branches.** Fallback chain participants suspended on `fallback_locking_event_map[d]` while holding a slot in `AIOTaskScheduler`'s 64-slot semaphore; those events fire only when other (queued) participants run, producing a cluster-wide stall under load. Adds `create_unbounded_task` and routes fallback dispatch and other always-sleepy handler paths through it (`4315b37`, `385633c`).
- **Fix duplicate egress on rw-set rescheduling.** When a fallback rw-set changed, the txn was marked failed but the egress block still fired because `client_responses` was populated. Skip egress when `rw_changed=True`; batch the post-fallback egress with a single `send_batch()` (`385633c`).
- **Relax `has_fallback_rw_set_changed`.** Writes/reads of keys absent from committed state are insert-safe and no longer trigger reschedule (`385633c`).

### Performance
- **Drop redundant `networking_locks`** from handlers without internal awaits (Ack, ChainAbort, ResponseToRoot, Unlock, DeterministicReordering, AriaCommit, AriaProcessingDone, SyncCleanup, AriaFallback*, RunFunRemote, WrongPartitionRequest, AsyncMigration, and the migration key-fetch trio in `worker_service`). Single-threaded asyncio already gives atomicity for sync critical sections (`385633c`).
- **Replace `fractions.Fraction` with `float`** for chain ACK accounting. ~100× cheaper per add; ε=1e-9 tolerance is safely below realistic chain depth/fan-out (safe to ~4.5M leaves; TPC-C chains have <1k) (`385633c`).
- Replace one msgpack encode/decode roundtrip with a shallow `dict(...)` copy on the hot path; switch fallback egress from `send_immediate` to batched `send` (`385633c`).

### Misc
- Version bumps for ruff, msgspec, aiokafka, confluent-kafka, boto3, prometheus-client, aiohttp, and base Python image (`37bb8dc`).

## Test plan
- [x] Unit tests: `pytest tests/unit/` — 726 passing
- [x] `ruff check` clean for all modified files
- [x] TPC-C 1-warehouse end-to-end run (manual)
- [x] YCSB-T end-to-end run (manual)
- [x] Verify no duplicate egress messages and `exactly_once_output: true` in result JSON